### PR TITLE
fix(mcp): sync server version and add external-content metadata regre…

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -13,10 +13,13 @@ import { discover } from './discovery/index.js';
 import { SessionCache } from './orchestration/cache.js';
 import { peek } from './read/peek.js';
 import { read } from './read/index.js';
+import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 const APITAP_DIR = join(homedir(), '.apitap');
+const require = createRequire(import.meta.url);
+const { version: PACKAGE_VERSION } = require('../package.json') as { version: string };
 
 /**
  * Wrap response data with external content metadata.
@@ -55,7 +58,7 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
 
   const server = new McpServer({
     name: 'apitap',
-    version: '0.5.0',
+    version: PACKAGE_VERSION,
   });
 
   // --- apitap_search ---


### PR DESCRIPTION
…ssions

- Use package.json version for MCP server metadata instead of hardcoded 0.5.0\n- Add regression test that apitap_replay sets _meta.externalContent.untrusted\n- Add regression test that apitap_read sets _meta.externalContent.untrusted