### PR TITLE
fix: extension auth tokens transfer to CLI replay engine (bug #7)

### DIFF
--- a/extension/popup.css
+++ b/extension/popup.css
@@ -101,7 +101,7 @@ button#btn-stop {
 .index-header { display: flex; justify-content: space-between; }
 .hit-count { color: #666; font-size: 12px; }
 .index-meta { font-size: 12px; color: #888; margin: 2px 0; }
-.index-actions { margin-top: 4px; }
+.index-actions { margin-top: 4px; margin-bottom: 6px; }
 .btn-promote { font-size: 11px; padding: 2px 8px; cursor: pointer; width: auto; display: inline-block; }
 .badge.promoted { font-size: 11px; color: #4a9; }
 .setting-row { margin-bottom: 12px; }
@@ -163,6 +163,15 @@ button#btn-stop {
   color: #d32f2f;
   line-height: 1;
 }
+/* --- Current site card (Capture tab) --- */
+#current-site { margin-bottom: 10px; }
+#current-site:empty { display: none; }
+.current-site-domain { font-weight: 600; font-size: 13px; margin-bottom: 4px; }
+.current-site-meta { font-size: 11px; color: #888; margin-bottom: 4px; }
+.current-site-endpoints { font-family: monospace; font-size: 11px; line-height: 1.6; max-height: 140px; overflow-y: auto; }
+.current-site-endpoints .endpoint { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.current-site-section { margin-bottom: 6px; }
+.current-site-empty { font-size: 11px; color: #999; font-style: italic; }
 .hidden { display: none; }
 .input-narrow { width: 40px; }
 
@@ -247,4 +256,6 @@ button#btn-stop {
   input[type="number"], input[type="checkbox"] { accent-color: #00e5c0; }
   .autolearn-section { border-top-color: #333; }
   .toggle-slider { background: #555; }
+  .current-site-meta { color: #777; }
+  .current-site-empty { color: #666; }
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -18,6 +18,7 @@
     </div>
 
     <div id="tab-capture" class="tab-content active">
+      <div id="current-site"></div>
       <div id="status">Ready</div>
       <div id="stats" hidden>
         <span id="endpoint-count">0</span> endpoints &middot;
@@ -46,7 +47,7 @@
     </div>
 
     <div id="tab-index" class="tab-content hidden">
-      <div id="index-actions" style="margin-bottom: 6px;">
+      <div id="index-actions">
         <button id="btn-exclude-domain" class="btn-small">+ Exclude this site</button>
       </div>
       <div id="index-list"></div>

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -31,6 +31,7 @@ function connectNativePort(): void {
   try {
     nativePort = chrome.runtime.connectNative(NATIVE_HOST);
     bridgeAvailable = true;
+    console.log('[apitap] native host connected');
 
     nativePort.onMessage.addListener((message: any) => {
       // Check if this is a response to a message we sent
@@ -53,6 +54,8 @@ function connectNativePort(): void {
     });
 
     nativePort.onDisconnect.addListener(() => {
+      const err = chrome.runtime.lastError;
+      console.warn('[apitap] native host disconnected:', err?.message ?? 'no error');
       bridgeAvailable = false;
       nativePort = null;
       // Reject all pending messages
@@ -68,14 +71,15 @@ function connectNativePort(): void {
       // Reconnect after a delay
       setTimeout(connectNativePort, 5000);
     });
-  } catch {
+  } catch (e) {
+    console.warn('[apitap] connectNativePort failed:', e);
     bridgeAvailable = false;
     nativePort = null;
   }
 }
 
 // Send a message to the native host and wait for response
-function sendNativePortMessage(message: any, timeout = 10_000): Promise<any> {
+function sendNativePortMessage(message: any, timeout = 30_000): Promise<any> {
   return new Promise((resolve) => {
     if (!nativePort) {
       resolve({ success: false, error: 'native host not connected' });
@@ -104,14 +108,19 @@ async function checkBridge(): Promise<boolean> {
 }
 
 async function saveViaBridge(skills: Array<{ domain: string; skillJson: string }>): Promise<{ success: boolean; paths?: string[]; error?: string }> {
-  if (skills.length === 1) {
-    return sendNativePortMessage({
+  // Send each skill individually to avoid giant batch messages timing out
+  const paths: string[] = [];
+  for (const skill of skills) {
+    const timeout = Math.max(30_000, Math.ceil(skill.skillJson.length / 50_000) * 5_000);
+    const result = await sendNativePortMessage({
       action: 'save_skill',
-      domain: skills[0].domain,
-      skillJson: skills[0].skillJson,
-    });
+      domain: skill.domain,
+      skillJson: skill.skillJson,
+    }, timeout);
+    if (result.success && result.path) paths.push(result.path);
+    else if (!result.success) console.warn('[apitap] save_skill failed for', skill.domain, ':', result.error);
   }
-  return sendNativePortMessage({ action: 'save_batch', skills });
+  return { success: paths.length > 0, paths };
 }
 
 // --- Agent-initiated capture ---
@@ -173,6 +182,21 @@ chrome.notifications.onClosed.addListener((notifId, byUser) => {
     pending.resolve(false);
   }
 });
+
+/** Find an existing tab for a domain — never opens a new one. Returns null if none found. */
+async function findExistingTab(domain: string): Promise<chrome.tabs.Tab | null> {
+  return new Promise((resolve) => {
+    chrome.tabs.query({ url: `*://${domain}/*` }, (tabs) => {
+      const valid = tabs.filter(t => t.url && t.url !== 'about:blank' && !t.url.startsWith('chrome://'));
+      if (valid.length > 0) {
+        const active = valid.find(t => t.active) ?? valid[0];
+        resolve(active);
+      } else {
+        resolve(null);
+      }
+    });
+  });
+}
 
 async function findOrOpenTab(domain: string): Promise<chrome.tabs.Tab> {
   return new Promise((resolve) => {
@@ -801,12 +825,18 @@ async function checkAutoLearn(domain: string): Promise<void> {
 
     autoLearnInProgress = true;
     try {
-      const tab = await findOrOpenTab(domain);
-      if (!tab.id) return;
-      const skillFiles = await captureWithPlateau(tab.id, {
-        idleTimeout: 10_000,
-        maxDuration: 120_000,
-      });
+      // Only attempt CDP capture if a tab for this domain is already open.
+      // NEVER open new tabs for auto-learn — causes phantom tabs for CDN/tracker domains.
+      const existingTab = await findExistingTab(domain);
+      let skillFiles: string[] = [];
+
+      if (existingTab?.id) {
+        skillFiles = await captureWithPlateau(existingTab.id, {
+          idleTimeout: 10_000,
+          maxDuration: 120_000,
+        });
+      }
+
       if (skillFiles.length > 0 && bridgeAvailable && nativePort) {
         const skills = skillFiles.map(json => {
           const parsed = JSON.parse(json);
@@ -826,7 +856,7 @@ async function checkAutoLearn(domain: string): Promise<void> {
         indexDirty = true;
         await flushIndex();
       } else {
-        // v1.5.1: CDP capture failed — generate skeleton skill file from index entry
+        // No existing tab or CDP capture failed — generate skeleton skill file from index
         if (bridgeAvailable && nativePort && entry.endpoints.length > 0) {
           const skeleton = generateSkeletonSkillFile(entry);
           const skeletonJson = JSON.stringify(skeleton);
@@ -894,6 +924,7 @@ function startCapture(tabId: number) {
 
 async function stopCapture() {
   if (!state.active || state.tabId === null) return;
+  state.active = false; // prevent re-entry while async saves run
 
   // Clear capture timeout
   if (captureTimeout) {
@@ -923,19 +954,33 @@ async function stopCapture() {
 
   // Auto-save via native messaging if bridge is available
   state.autoSaved = null;
-  if (bridgeAvailable && allSkillFiles.length > 0) {
-    const skills = allSkillFiles.map(json => {
-      const parsed = JSON.parse(json);
-      return { domain: parsed.domain, skillJson: json };
-    });
+  const capturedSkills = allSkillFiles.map(json => {
+    const parsed = JSON.parse(json);
+    return { domain: parsed.domain, skillJson: json };
+  });
 
-    const result = await saveViaBridge(skills);
+  if (bridgeAvailable && capturedSkills.length > 0) {
+    const result = await saveViaBridge(capturedSkills);
     if (result.success) {
-      state.autoSaved = result.paths ?? skills.map(s => s.domain);
+      state.autoSaved = result.paths ?? capturedSkills.map(s => s.domain);
     }
   }
 
-  state.active = false;
+  // Save auth tokens — runs even if skill save failed (auth is small)
+  if (bridgeAvailable) {
+    const domains = new Set(capturedSkills.map(s => s.domain));
+    for (const domain of domains) {
+      const tokens = await getAuthTokens(domain);
+      if (tokens.length > 0) {
+        await sendNativePortMessage({
+          action: 'save_auth',
+          domain,
+          headers: tokens,
+        });
+      }
+    }
+  }
+
   state.tabId = null;
 
   // Clear sensitive data (auth headers, POST bodies)
@@ -1004,7 +1049,10 @@ chrome.runtime.onMessage.addListener(
           // Download from background — popup blob URLs die when popup closes
           const skill = JSON.parse(lastSkillJson);
           const filename = `${skill.domain || 'skill'}.json`;
-          const dataUrl = 'data:application/json;base64,' + btoa(String.fromCharCode(...new TextEncoder().encode(lastSkillJson)));
+          const bytes = new TextEncoder().encode(lastSkillJson);
+          let binary = '';
+          for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+          const dataUrl = 'data:application/json;base64,' + btoa(binary);
           chrome.downloads.download({ url: dataUrl, filename, saveAs: true }, () => {
             sendResponse({ type: 'CAPTURE_COMPLETE', skillJson: lastSkillJson! } as CaptureResponse);
           });

--- a/extension/src/observer.ts
+++ b/extension/src/observer.ts
@@ -32,18 +32,36 @@ function isApiContentType(contentType: string): boolean {
     ct.includes('application/vnd.api+json');
 }
 
-/** Extract ALL matching auth headers (v1.5.1: multi-header for Twitch etc.) */
+/** Headers that are always auth-related regardless of name pattern */
+const KNOWN_AUTH_HEADERS = new Set([
+  'authorization', 'x-api-key', 'client-id', 'x-auth-token',
+]);
+
+/** Header name patterns that suggest auth (case-insensitive) */
+const AUTH_PATTERNS = /bearer|token|apikey|api-key|auth/i;
+
+/** Headers to never capture (noise, not auth) */
+const SKIP_HEADERS = new Set([
+  'cookie', 'set-cookie', 'content-type', 'accept', 'user-agent',
+  'referer', 'origin', 'cache-control', 'traceparent', 'tracestate',
+  'tracecontext', 'newrelic', 'content-length',
+]);
+
+/** Extract ALL matching auth headers (v1.5.2: pattern-based for custom bearer headers) */
 export function extractAuthTokens(headers: Record<string, string>): Array<{ header: string; value: string }> {
   const tokens: Array<{ header: string; value: string }> = [];
-  const auth = headers['authorization'] || headers['Authorization'];
-  if (auth) tokens.push({ header: 'authorization', value: auth });
-  const apiKey = headers['x-api-key'] || headers['X-Api-Key'];
-  if (apiKey) tokens.push({ header: 'x-api-key', value: apiKey });
-  const clientId = headers['client-id'] || headers['Client-ID'] || headers['Client-Id'];
-  if (clientId) tokens.push({ header: 'client-id', value: clientId });
-  const xAuthToken = headers['x-auth-token'] || headers['X-Auth-Token'];
-  if (xAuthToken) tokens.push({ header: 'x-auth-token', value: xAuthToken });
-  // Skip cookies — too broad and session-specific
+  const seen = new Set<string>();
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (SKIP_HEADERS.has(lower)) continue;
+    if (!value || value.length < 8) continue; // too short to be a token
+    if (KNOWN_AUTH_HEADERS.has(lower) || AUTH_PATTERNS.test(lower)) {
+      if (!seen.has(lower)) {
+        seen.add(lower);
+        tokens.push({ header: lower, value });
+      }
+    }
+  }
   return tokens;
 }
 

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -294,9 +294,107 @@ document.getElementById('dismiss-banner')!.addEventListener('click', () => {
   chrome.storage.local.set({ bannerDismissed: true });
 });
 
+// --- Current site display (Capture tab) ---
+
+function renderCurrentSite(index: any, domain: string) {
+  const container = document.getElementById('current-site')!;
+  container.textContent = '';
+
+  if (!index || !domain) {
+    const empty = document.createElement('div');
+    empty.className = 'current-site-empty';
+    empty.textContent = 'No API traffic for this site yet.';
+    container.appendChild(empty);
+    return;
+  }
+
+  const baseDomain = domain.replace(/^www\./, '');
+  const entry = index.entries?.find((e: any) => e.domain === domain || e.domain === baseDomain);
+  // Also find entries for subdomains (api.example.com when on example.com)
+  const entryDomain = entry?.domain;
+  const related = index.entries?.filter((e: any) =>
+    e.domain !== domain && e.domain !== baseDomain &&
+    (e.domain.endsWith('.' + baseDomain) || baseDomain.endsWith('.' + e.domain))
+  ) ?? [];
+
+  if (!entry && related.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'current-site-empty';
+    empty.textContent = 'No API traffic for this site yet.';
+    container.appendChild(empty);
+    return;
+  }
+
+  const all = entry ? [entry, ...related] : related;
+
+  for (const e of all) {
+    const section = document.createElement('div');
+    section.className = 'current-site-section';
+
+    const header = document.createElement('div');
+    header.className = 'current-site-domain';
+    const statusIcon = e.promoted ? '\u2705 ' : '';
+    header.textContent = statusIcon + e.domain;
+
+    const meta = document.createElement('div');
+    meta.className = 'current-site-meta';
+    const authTypes = [...new Set(e.endpoints.map((ep: any) => ep.authType).filter(Boolean))];
+    meta.textContent = e.endpoints.length + ' endpoint' + (e.endpoints.length !== 1 ? 's' : '')
+      + ' \u00b7 ' + e.totalHits + ' hits'
+      + (authTypes.length > 0 ? ' \u00b7 ' + authTypes.join(', ') : '')
+      + (e.promoted ? ' \u00b7 skill file saved' : '');
+
+    const epList = document.createElement('div');
+    epList.className = 'current-site-endpoints';
+    for (const ep of e.endpoints) {
+      for (const method of (ep.methods ?? ['?'])) {
+        const div = document.createElement('div');
+        div.className = 'endpoint';
+        const m = document.createElement('span');
+        m.className = VALID_METHODS.has(method) ? 'method ' + method : 'method';
+        m.textContent = method;
+        div.appendChild(m);
+        div.appendChild(document.createTextNode(' ' + ep.path));
+        epList.appendChild(div);
+      }
+    }
+
+    section.appendChild(header);
+    section.appendChild(meta);
+    if (e.promoted) {
+      const badge = document.createElement('div');
+      badge.className = 'badge promoted';
+      badge.textContent = 'Skill file exists';
+      section.appendChild(badge);
+    }
+    section.appendChild(epList);
+    container.appendChild(section);
+  }
+}
+
+function loadCurrentSite() {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const tab = tabs[0];
+    if (!tab?.url) return;
+    let domain: string;
+    try {
+      domain = new URL(tab.url).hostname;
+    } catch { return; }
+
+    chrome.runtime.sendMessage({ type: 'GET_INDEX' }, (response: any) => {
+      if (response?.index) {
+        renderCurrentSite(response.index, domain);
+      }
+    });
+  });
+}
+
 // --- Init: restore state from session storage, then sync with background ---
 
 (async () => {
+  // Load current site's index data
+  loadCurrentSite();
+
   // Restore skill JSON from session storage (survives popup close/reopen)
   const stored = await chrome.storage.session.get(['lastSkillJson']);
   if (stored.lastSkillJson) {

--- a/src/native-host.ts
+++ b/src/native-host.ts
@@ -299,7 +299,7 @@ function readMessage(): Promise<NativeRequest | null> {
       }
 
       const messageLength = headerBuf.readUInt32LE(0);
-      if (messageLength > 1024 * 1024) {
+      if (messageLength > 10 * 1024 * 1024) {
         process.stderr.write(`Message too large: ${messageLength}\n`);
         resolve(null);
         return;
@@ -416,6 +416,10 @@ if (isMainModule) {
 
       // Otherwise, handle as a direct extension message (save_skill, etc.)
       const response = await handleNativeMessage(message);
+      // Echo _portMsgId so extension can match response to request
+      if ((message as any)._portMsgId) {
+        (response as any)._portMsgId = (message as any)._portMsgId;
+      }
       sendMessage(response);
     }
 

--- a/test/extension/auth-token.test.ts
+++ b/test/extension/auth-token.test.ts
@@ -12,12 +12,12 @@ describe('extractAuthToken (legacy single-header)', () => {
   });
 
   it('extracts API key from x-api-key header', () => {
-    const token = extractAuthToken({ 'x-api-key': 'sk-abc123' });
-    assert.deepEqual(token, { header: 'x-api-key', value: 'sk-abc123' });
+    const token = extractAuthToken({ 'x-api-key': 'sk-abc123-long-enough' });
+    assert.deepEqual(token, { header: 'x-api-key', value: 'sk-abc123-long-enough' });
   });
 
   it('returns undefined for cookie-only auth (too broad)', () => {
-    const token = extractAuthToken({ cookie: 'session=abc' });
+    const token = extractAuthToken({ cookie: 'session=abc123456789' });
     assert.equal(token, undefined);
   });
 
@@ -28,22 +28,22 @@ describe('extractAuthToken (legacy single-header)', () => {
 
   it('prefers Authorization over x-api-key', () => {
     const token = extractAuthToken({
-      authorization: 'Bearer xyz',
-      'x-api-key': 'sk-abc',
+      authorization: 'Bearer xyz-long-enough',
+      'x-api-key': 'sk-abc-long-enough',
     });
     assert.equal(token!.header, 'authorization');
   });
 });
 
-describe('extractAuthTokens (v1.5.1 multi-header)', () => {
+describe('extractAuthTokens (v1.5.2 pattern-based)', () => {
   it('returns all matching auth headers', () => {
     const tokens = extractAuthTokens({
-      authorization: 'OAuth xyz',
+      authorization: 'OAuth xyz-long-enough',
       'client-id': 'kimne78kx3ncx6brgo4mv6wki5h1ko',
     });
     assert.equal(tokens.length, 2);
-    assert.deepEqual(tokens[0], { header: 'authorization', value: 'OAuth xyz' });
-    assert.deepEqual(tokens[1], { header: 'client-id', value: 'kimne78kx3ncx6brgo4mv6wki5h1ko' });
+    assert.deepEqual(tokens.find(t => t.header === 'authorization'), { header: 'authorization', value: 'OAuth xyz-long-enough' });
+    assert.deepEqual(tokens.find(t => t.header === 'client-id'), { header: 'client-id', value: 'kimne78kx3ncx6brgo4mv6wki5h1ko' });
   });
 
   it('returns empty array when no auth headers present', () => {
@@ -52,25 +52,59 @@ describe('extractAuthTokens (v1.5.1 multi-header)', () => {
   });
 
   it('captures x-auth-token header', () => {
-    const tokens = extractAuthTokens({ 'x-auth-token': 'abc123' });
+    const tokens = extractAuthTokens({ 'x-auth-token': 'abc12345-long-enough' });
     assert.equal(tokens.length, 1);
-    assert.deepEqual(tokens[0], { header: 'x-auth-token', value: 'abc123' });
+    assert.deepEqual(tokens[0], { header: 'x-auth-token', value: 'abc12345-long-enough' });
   });
 
   it('captures Client-ID with various casings', () => {
-    const tokens = extractAuthTokens({ 'Client-ID': 'test-id' });
+    const tokens = extractAuthTokens({ 'Client-ID': 'test-id-long-enough' });
     assert.equal(tokens.length, 1);
     assert.equal(tokens[0].header, 'client-id');
   });
 
   it('returns single header when only one matches', () => {
-    const tokens = extractAuthTokens({ authorization: 'Bearer xyz' });
+    const tokens = extractAuthTokens({ authorization: 'Bearer xyz-long-enough' });
     assert.equal(tokens.length, 1);
-    assert.deepEqual(tokens[0], { header: 'authorization', value: 'Bearer xyz' });
+    assert.deepEqual(tokens[0], { header: 'authorization', value: 'Bearer xyz-long-enough' });
   });
 
   it('skips cookies (too broad and session-specific)', () => {
-    const tokens = extractAuthTokens({ cookie: 'session=abc', authorization: 'Bearer xyz' });
+    const tokens = extractAuthTokens({ cookie: 'session=abc123456789', authorization: 'Bearer xyz-long-enough' });
+    assert.equal(tokens.length, 1);
+    assert.equal(tokens[0].header, 'authorization');
+  });
+
+  it('captures custom bearer/token headers like Nordstrom', () => {
+    const tokens = extractAuthTokens({
+      'nord-shopper-bearer-token': 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIyODI3',
+      'x-shopper-token': 'abc123def456ghi789',
+      'content-type': 'application/json',
+      'user-agent': 'Mozilla/5.0',
+    });
+    assert.equal(tokens.length, 2);
+    assert.ok(tokens.find(t => t.header === 'nord-shopper-bearer-token'));
+    assert.ok(tokens.find(t => t.header === 'x-shopper-token'));
+  });
+
+  it('skips values shorter than 8 characters', () => {
+    const tokens = extractAuthTokens({ authorization: 'short' });
+    assert.equal(tokens.length, 0);
+  });
+
+  it('captures apikey headers', () => {
+    const tokens = extractAuthTokens({ apikey: 'long-api-key-value-here' });
+    assert.equal(tokens.length, 1);
+    assert.equal(tokens[0].header, 'apikey');
+  });
+
+  it('skips noise headers like traceparent and newrelic', () => {
+    const tokens = extractAuthTokens({
+      traceparent: '00-abc123def456-789-01',
+      newrelic: 'long-newrelic-agent-string-here',
+      tracecontext: 'some-long-trace-context',
+      authorization: 'Bearer real-token-here',
+    });
     assert.equal(tokens.length, 1);
     assert.equal(tokens[0].header, 'authorization');
   });


### PR DESCRIPTION
## Summary

- **Root cause fix**: Native host now echoes `_portMsgId` in responses, enabling request-response matching for all native messaging (was causing universal timeouts)
- **Auth save in `stopCapture()`**: After saving skill files, extension iterates captured domains and sends `save_auth` with session-stored tokens → native host → `AuthManager.store()` → `auth.enc`
- **Pattern-based auth extraction**: `extractAuthTokens()` upgraded from 4 hardcoded headers to regex pattern matching — catches custom headers like `x-shopper-bearer-token`, `x-shopper-token`, `apikey`
- **Individual skill saves**: `saveViaBridge` sends each skill file individually with size-based timeouts instead of batch (prevents timeout on large skill files)
- **Native host message limit**: Raised from 1MB to 10MB for large skill files
- **Phantom tab fix**: Auto-learn uses `findExistingTab()` instead of `findOrOpenTab()` — never opens new tabs for CDN/tracker domains
- **Popup CSP fix**: Inline styles moved to CSS classes
- **Popup current site card**: Shows index data for the active tab's domain on Capture tab

## Test plan

- [x] 1176 tests pass (1174 pass, 2 pre-existing browser nav failures)
- [x] Auth token extraction: 20 tests including custom bearer headers, noise header skipping, min-length filtering
- [x] Native host: 15 tests including socket relay, concurrent connections
- [x] End-to-end verified: extension capture → auth saved → CLI `auth show` confirms storage → `replay` returns 200 with live authenticated data
- [x] Security audit: no secrets, tokens, PII, or local paths in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)