### PR TITLE
fix: store auth credentials from CDP attach and reduce false positives

### DIFF
--- a/src/capture/cdp-attach.ts
+++ b/src/capture/cdp-attach.ts
@@ -3,7 +3,7 @@ import http from 'node:http';
 import { homedir } from 'node:os';
 import type { CapturedExchange } from '../types.js';
 import { shouldCapture } from './filter.js';
-import { SkillGenerator } from '../skill/generator.js';
+import { SkillGenerator, deduplicateAuth } from '../skill/generator.js';
 import { signSkillFile } from '../skill/signing.js';
 import { writeSkillFile } from '../skill/store.js';
 import { AuthManager, getMachineId } from '../auth/manager.js';
@@ -445,25 +445,10 @@ export async function attach(options: AttachOptions): Promise<AttachResult> {
         let skill = gen.toSkillFile(domain);
         if (skill.endpoints.length === 0) continue;
 
-        // Store extracted auth credentials — deduplicate by header name,
-        // keeping the first (highest-priority) value for each header
-        const extractedAuth = gen.getExtractedAuth();
-        if (extractedAuth.length > 0) {
-          const seen = new Set<string>();
-          const uniqueHeaders: Array<{ header: string; value: string }> = [];
-          for (const a of extractedAuth) {
-            if (!seen.has(a.header)) {
-              seen.add(a.header);
-              uniqueHeaders.push({ header: a.header, value: a.value });
-            }
-          }
-          const primary = extractedAuth[0];
-          await authManager.store(domain, {
-            type: primary.type,
-            header: primary.header,
-            value: primary.value,
-            headers: uniqueHeaders,
-          });
+        // Store extracted auth credentials
+        const auth = deduplicateAuth(gen.getExtractedAuth());
+        if (auth) {
+          await authManager.store(domain, auth);
         }
 
         // Store OAuth credentials if detected

--- a/src/capture/session.ts
+++ b/src/capture/session.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { shouldCapture } from './filter.js';
 import { launchBrowser, normalizeCookiesForStorageState } from './browser.js';
 import { isDomainMatch } from './domain.js';
-import { SkillGenerator, type GeneratorOptions } from '../skill/generator.js';
+import { SkillGenerator, deduplicateAuth, type GeneratorOptions } from '../skill/generator.js';
 import { detectCaptcha } from '../auth/refresh.js';
 import { verifyEndpoints } from './verifier.js';
 import { signSkillFile } from '../skill/signing.js';
@@ -208,25 +208,10 @@ export class CaptureSession {
 
       if (skill.endpoints.length === 0) continue;
 
-      // Store extracted auth — deduplicate by header name,
-      // keeping the first (highest-priority) value for each header
-      const extractedAuth = generator.getExtractedAuth();
-      if (extractedAuth.length > 0) {
-        const seen = new Set<string>();
-        const uniqueHeaders: Array<{ header: string; value: string }> = [];
-        for (const a of extractedAuth) {
-          if (!seen.has(a.header)) {
-            seen.add(a.header);
-            uniqueHeaders.push({ header: a.header, value: a.value });
-          }
-        }
-        const primary = extractedAuth[0];
-        await authManager.store(domain, {
-          type: primary.type,
-          header: primary.header,
-          value: primary.value,
-          headers: uniqueHeaders,
-        });
+      // Store extracted auth credentials
+      const auth = deduplicateAuth(generator.getExtractedAuth());
+      if (auth) {
+        await authManager.store(domain, auth);
       }
 
       // Store OAuth credentials if detected

--- a/src/skill/generator.ts
+++ b/src/skill/generator.ts
@@ -132,6 +132,25 @@ function extractAuth(headers: Record<string, string>): [StoredAuth[], Set<string
   return [auth, entropyDetected];
 }
 
+/**
+ * Deduplicate extracted auth entries by header name and build a StoredAuth
+ * object with all unique headers. Entries are expected to be pre-sorted
+ * by priority (bearer > api-key > custom) via getExtractedAuth().
+ */
+export function deduplicateAuth(extractedAuth: StoredAuth[]): StoredAuth | null {
+  if (extractedAuth.length === 0) return null;
+  const seen = new Set<string>();
+  const headers: Array<{ header: string; value: string }> = [];
+  for (const a of extractedAuth) {
+    if (!seen.has(a.header)) {
+      seen.add(a.header);
+      headers.push({ header: a.header, value: a.value });
+    }
+  }
+  const primary = extractedAuth[0];
+  return { type: primary.type, header: primary.header, value: primary.value, headers };
+}
+
 function generateEndpointId(method: string, parameterizedPath: string): string {
   // Clean framework noise for the ID (but not for the stored path)
   let cleaned = cleanFrameworkPath(parameterizedPath);


### PR DESCRIPTION
## Summary

- **CDP attach auth storage**: The CDP attach shutdown path generated skill files with `[stored]` header placeholders but never persisted credentials to `AuthManager`. Replay against CDP-captured skills always failed with 401/403. Fixed by adding `AuthManager.store()` and OAuth credential storage to the attach shutdown handler.
- **Auth extraction false positives**: Entropy-based header detection was matching browser and observability headers (`traceparent`, `tracestate`, `newrelic`, `sentry-trace`, `sec-ch-ua`, `referer`, `user-agent`, etc.) as auth tokens. Added `NOT_AUTH_HEADERS` skip set for known non-auth high-entropy headers.
- **Multi-header auth storage**: Both capture paths (`session.ts`, `cdp-attach.ts`) only stored `extractedAuth[0]`, losing all other auth headers. Now deduplicates by header name and stores all unique headers via `StoredAuth.headers` array.
- **Auth priority sorting**: `getExtractedAuth()` now sorts by type priority (bearer > api-key > custom) so the most relevant credential is used as the primary.

## Files changed

- `src/capture/cdp-attach.ts` — Add `AuthManager` + OAuth storage to shutdown
- `src/capture/session.ts` — Multi-header dedup auth storage (same pattern as cdp-attach)
- `src/skill/generator.ts` — `NOT_AUTH_HEADERS` set, `sec-*`/`STRIP_HEADERS` guard in `extractAuth()`, priority sort in `getExtractedAuth()`

## Test plan

- [x] `test/skill/generator.test.ts` — 44 pass
- [x] `test/capture/cdp-attach.test.ts` — 11 pass
- [ ] Manual: CDP attach → browse authenticated site → Ctrl+C → verify `auth.enc` updated → replay returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)