### PR TITLE
fix: 23 medium security findings (SSRF, auth scoping, rate limiting, key scrubbing)

### DIFF
--- a/src/auth/handoff.ts
+++ b/src/auth/handoff.ts
@@ -296,7 +296,7 @@ async function doHandoff(
       const cookieDomain = (c.domain || '').replace(/^\./, ''); // Remove leading dot
       return cookieDomain === domain ||
         cookieDomain.endsWith('.' + domain) ||
-        domain.endsWith('.' + cookieDomain);
+        (domain.endsWith('.' + cookieDomain) && cookieDomain.includes('.'));
     });
 
     if (cookies.length === 0 && !authDetected) {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -265,8 +265,11 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
       },
     },
     async ({ requests, maxBytes }) => {
-      if (!rateLimiter.check()) {
-        return { content: [{ type: 'text' as const, text: 'Rate limit exceeded. Try again in a moment.' }], isError: true };
+      // Consume one rate-limit token per batch item
+      for (let i = 0; i < requests.length; i++) {
+        if (!rateLimiter.check()) {
+          return { content: [{ type: 'text' as const, text: `Rate limit exceeded after ${i} of ${requests.length} items. Try again in a moment.` }], isError: true };
+        }
       }
       const { replayMultiple } = await import('./replay/engine.js');
       const typed = requests.map(r => ({
@@ -337,6 +340,9 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
       },
     },
     async ({ url }) => {
+      if (!rateLimiter.check()) {
+        return { content: [{ type: 'text' as const, text: 'Rate limit exceeded. Try again in a moment.' }], isError: true };
+      }
       try {
         if (!options._skipSsrfCheck) {
           const validation = await resolveAndValidateUrl(url);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -30,7 +30,11 @@ const APITAP_DIR = join(homedir(), '.apitap');
 
 /** M20: Mark plugin responses as untrusted external content */
 function wrapUntrusted(data: unknown): unknown {
-  return { ...data as Record<string, unknown>, _meta: { externalContent: { untrusted: true } } };
+  const meta = { externalContent: { untrusted: true } };
+  if (Array.isArray(data)) {
+    return { results: data, _meta: meta };
+  }
+  return { ...data as Record<string, unknown>, _meta: meta };
 }
 
 export function createPlugin(options: PluginOptions = {}): Plugin {


### PR DESCRIPTION
## Summary

Fixes all 23 medium findings from the security audit. No test regressions: 1001 pass / 50 fail (all pre-existing).

## Changes by category

**SSRF Prevention (M7, M14-M19)**
- `validateUrl()` on all navigate URLs
- Post-fetch DNS re-validation in replay engine
- CGNAT/IETF/benchmarking/reserved IPv4 ranges blocked
- `normalizeIpv4()` prevents decimal/octal/hex IP bypass
- `safeFetch()` → `resolveAndValidateUrl()`
- SSRF validation added to plugin capture tool
- `_skipSsrfCheck` documented as `@internal` testing-only

**Auth Scoping (M3, M4, M13)**
- Auth tokens filtered by request origin in handoff
- Cookies filtered to target domain in handoff
- Handoff grace period extended to ~8s for MFA/CAPTCHA flows

**Credential Scrubbing (M12)**
- AWS/GCP key, PEM private key, Basic auth scrubbing patterns added

**Signing & Validation (M8, M10, M11)**
- Recursive `sortKeysDeep()` for JSON canonicalization
- Deep type validation for headers/queryParams/requestBody
- Signature verification default-on (already fixed by H1)

**Infrastructure (M1, M2, M5)**
- Random per-install ID fallback instead of hostname+homedir
- Only catch ENOENT for salt fallback, throw on other errors
- Mode `0o700` on all directory creation

**Rate Limiting & Untrusted Metadata (M20-M23)**
- Sliding-window rate limiter on MCP outbound tools
- Third-party requests changed from opt-out to opt-in
- Untrusted metadata on plugin and serve.ts responses

## Test plan
- [x] `npm test` — 1001 pass / 50 fail (all 50 pre-existing, no regressions)
- [ ] Manual: replay a skill file, verify SSRF blocks `http://169.254.169.254`
- [ ] Manual: verify `0177.0.0.1` (octal localhost) blocked by normalizeIpv4()

🤖 Generated with [Claude Code](https://claude.com/claude-code)