### PR TITLE
Fix --no-auth-only flag for APIs.guru bulk import

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -766,6 +766,7 @@ async function handleApisGuruImport(flags: Record<string, string | boolean>): Pr
   const force = flags.force === true;
   const limit = typeof flags.limit === 'string' ? parseInt(flags.limit, 10) : 100;
   const search = typeof flags.search === 'string' ? flags.search : undefined;
+  const noAuthOnly = flags['no-auth-only'] === true;
   const skillsDir = SKILLS_DIR || join(APITAP_DIR, 'skills');
 
   if (!json) {
@@ -829,6 +830,16 @@ async function handleApisGuruImport(flags: Record<string, string | boolean>): Pr
       if (endpoints.length === 0) {
         if (!json) {
           console.log(`  [${idx}/${total}] SKIP ${domain.padEnd(24)} 0 endpoints  (${entry.title})`);
+        }
+        results.push({ index: i + 1, status: 'skip', domain, title: entry.title, endpointsAdded: 0 });
+        skippedApis++;
+        continue;
+      }
+
+      // Skip auth-required APIs when --no-auth-only is set
+      if (noAuthOnly && meta.requiresAuth) {
+        if (!json) {
+          console.log(`  [${idx}/${total}] SKIP ${domain.padEnd(24)} requires auth  (${entry.title})`);
         }
         results.push({ index: i + 1, status: 'skip', domain, title: entry.title, endpointsAdded: 0 });
         skippedApis++;

--- a/src/skill/apis-guru.ts
+++ b/src/skill/apis-guru.ts
@@ -88,7 +88,6 @@ export function parseApisGuruList(raw: Record<string, any>): ApisGuruEntry[] {
 export interface FilterOptions {
   search?: string;
   limit?: number;
-  noAuthOnly?: boolean;
   preferOpenapi3?: boolean;
 }
 


### PR DESCRIPTION
## Summary

The `--no-auth-only` flag on `apitap import --from apis-guru` was defined in the `FilterOptions` interface but never implemented. Auth-required APIs (Google Cloud, AWS, etc.) were imported even when the flag was set.

## Root Cause

The APIs.guru directory listing doesn't include `securitySchemes` — that information is only in the full OpenAPI spec. So filtering at the directory level (in `filterEntries()`) is impossible.

## Fix

Moved the auth check into the import loop, after `convertOpenAPISpec()` runs. The converter already calls `detectAuth()` which sets `meta.requiresAuth`. The CLI now checks this flag and skips with a clear message:

```
  [1/3] SKIP admin.googleapis.com     requires auth  (Admin SDK API)
  [2/3] SKIP appengine.googleapis.com requires auth  (App Engine Admin API)
  [3/3] SKIP bigtableadmin.googleapis.com requires auth  (Cloud Bigtable Admin API)
```

Also removed the dead `noAuthOnly` field from `FilterOptions` in `apis-guru.ts`.

## Files Changed

- `src/cli.ts` — Parse `--no-auth-only` flag, check `meta.requiresAuth` after conversion
- `src/skill/apis-guru.ts` — Remove dead `noAuthOnly` from `FilterOptions` interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)