### PR TITLE
Update README for v1.6 — OpenAPI import, confidence model, 6400+ endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Every endpoint tracks how it was discovered:
 | Source | Confidence | Meaning |
 |--------|-----------|---------|
 | Captured with response body | 1.0 | Full capture — response shape verified |
-| CDP skeleton (real traffic, no body) | 0.8 | Endpoint exists, body was evicted from Chrome buffer |
 | OpenAPI import, high quality | 0.85 | Spec has response examples |
+| CDP skeleton (real traffic, no body) | 0.8 | Endpoint exists, body was evicted from Chrome buffer |
 | OpenAPI import, base | 0.6 | Thin spec, no examples |
 
 Imported endpoints auto-upgrade to confidence 1.0 on first successful replay. The merge is additive — captured data is never overwritten by imports, imports fill gaps that capture missed.


### PR DESCRIPTION
## Summary

Updates the README to reflect v1.6.0-v1.6.3 changes. The product story has fundamentally shifted from "capture-only" to "instant API access for 280+ APIs, with capture for everything else."

## Key changes

- **Lead pitch** now opens with 6,400+ pre-mapped endpoints available on install
- **Import quick start** — full documentation for `apitap import` with all flags
- **Pre-Loaded APIs table** — Stripe (446), GitHub (499), Jira (487), Twilio (199+), Slack (175), etc.
- **Confidence Model section** — explains the 0.6-1.0 hierarchy (captured > skeleton > import)
- **Architecture diagram** — shows Import/Capture/Attach as three equal paths to skill files
- **Security section** — added atomic writes, safe JSON parsing, spec fetch hardening, external $ref rejection, 4-state provenance
- **Import flags table** in CLI reference (--from apis-guru, --search, --limit, --no-auth-only, --dry-run, --update, --force)
- **Test badge** — 1299 (was 1195)
- **New FAQ** — "Why not just use an OpenAPI spec?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)