### PR TITLE
refactor: extract safeReadSkillFile() helper

### DIFF
--- a/src/skill/search.ts
+++ b/src/skill/search.ts
@@ -1,5 +1,5 @@
 // src/skill/search.ts
-import { listSkillFiles, readSkillFile } from './store.js';
+import { listSkillFiles, safeReadSkillFile } from './store.js';
 
 export interface SearchResult {
   domain: string;
@@ -37,12 +37,7 @@ export async function searchSkills(
   const results: SearchResult[] = [];
 
   for (const summary of summaries) {
-    let skill;
-    try {
-      skill = await readSkillFile(summary.domain, skillsDir, { trustUnsigned: true });
-    } catch {
-      continue; // Skip files that fail to load
-    }
+    const skill = await safeReadSkillFile(summary.domain, skillsDir, { trustUnsigned: true });
     if (!skill) continue;
 
     const domainLower = skill.domain.toLowerCase();

--- a/src/skill/store.ts
+++ b/src/skill/store.ts
@@ -114,6 +114,24 @@ export async function readSkillFile(
   }
 }
 
+/**
+ * Fault-tolerant wrapper around readSkillFile — returns null instead of
+ * throwing on validation errors, bad signatures, etc.  ENOENT (missing
+ * file) also returns null.  Use this when iterating many files where one
+ * bad file should not abort the whole operation.
+ */
+export async function safeReadSkillFile(
+  domain: string,
+  skillsDir: string = DEFAULT_SKILLS_DIR,
+  options?: Parameters<typeof readSkillFile>[2],
+): Promise<SkillFile | null> {
+  try {
+    return await readSkillFile(domain, skillsDir, options);
+  } catch {
+    return null;
+  }
+}
+
 export async function listSkillFiles(
   skillsDir: string = DEFAULT_SKILLS_DIR,
 ): Promise<SkillSummary[]> {
@@ -131,19 +149,15 @@ export async function listSkillFiles(
     if (!file.endsWith('.json')) continue;
     const domain = file.replace(/\.json$/, '');
     if (!DOMAIN_RE.test(domain)) continue; // skip non-conforming filenames
-    try {
-      const skill = await readSkillFile(domain, skillsDir, { trustUnsigned: true });
-      if (skill) {
-        summaries.push({
-          domain: skill.domain,
-          skillFile: join(skillsDir, file),
-          endpointCount: skill.endpoints.length,
-          capturedAt: skill.capturedAt,
-          provenance: skill.provenance ?? 'unsigned',
-        });
-      }
-    } catch {
-      // Skip files that fail to load (bad signature, validation error, etc.)
+    const skill = await safeReadSkillFile(domain, skillsDir, { trustUnsigned: true });
+    if (skill) {
+      summaries.push({
+        domain: skill.domain,
+        skillFile: join(skillsDir, file),
+        endpointCount: skill.endpoints.length,
+        capturedAt: skill.capturedAt,
+        provenance: skill.provenance ?? 'unsigned',
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Extracts `safeReadSkillFile()` — a fault-tolerant wrapper around `readSkillFile()` that returns `null` on any error instead of throwing
- Replaces duplicated try/catch in `listSkillFiles()` and `searchSkills()` with the shared helper
- Future callers that iterate skill files get fault-tolerance by default

No behavior change — pure refactor.

## Test plan
- [x] 1304 tests pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)