### PR TITLE
fix(extension): add TTL and revocation UI for agent consent approvals

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -76,6 +76,11 @@
         <p class="setting-desc">These domains are ignored by passive indexing.</p>
         <div id="excluded-domains-list"></div>
       </div>
+      <div class="setting-row">
+        <label>Agent capture approvals</label>
+        <p class="setting-desc">Domains approved for agent capture (24h TTL).</p>
+        <div id="approved-domains-list"></div>
+      </div>
     </div>
   </div>
   <script src="dist/popup.js" type="module"></script>

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -126,7 +126,7 @@ async function saveViaBridge(skills: Array<{ domain: string; skillJson: string }
 
 // --- Agent-initiated capture ---
 
-import { isApproved, addApprovedDomain } from './consent.js';
+import { isApproved, addApprovedDomain, removeApprovedDomain, getApprovedDomainEntries } from './consent.js';
 
 // Pending consent callbacks — keyed by domain
 const pendingConsent = new Map<string, {
@@ -1177,6 +1177,25 @@ chrome.runtime.onMessage.addListener(
       case 'GET_INDEX': {
         sendResponse({ type: 'STATE_UPDATE', index: passiveIndex } as any);
         break;
+      }
+
+      case 'GET_APPROVED_DOMAINS': {
+        getApprovedDomainEntries().then((entries) => {
+          sendResponse({ type: 'STATE_UPDATE', approvedDomains: entries } as any);
+        });
+        return true;
+      }
+
+      case 'REMOVE_APPROVED_DOMAIN': {
+        if (!message.domain || !isValidDomain(message.domain)) {
+          sendResponse({ type: 'ERROR', error: 'Invalid domain' } as CaptureResponse);
+          break;
+        }
+        removeApprovedDomain(message.domain).then(async () => {
+          const entries = await getApprovedDomainEntries();
+          sendResponse({ type: 'STATE_UPDATE', approvedDomains: entries } as any);
+        });
+        return true;
       }
     }
   },

--- a/extension/src/consent.ts
+++ b/extension/src/consent.ts
@@ -1,37 +1,143 @@
 const STORAGE_KEY = 'approvedAgentDomains';
+export const CONSENT_TTL_MS = 24 * 60 * 60 * 1000;
 
-function getStorage(): Promise<string[]> {
+export interface ApprovedDomainEntry {
+  domain: string;
+  approvedAt: string;
+  expiresAt: string;
+}
+
+function isValidIsoDate(value: unknown): value is string {
+  return typeof value === 'string' && !Number.isNaN(Date.parse(value));
+}
+
+interface NormalizeResult {
+  entries: ApprovedDomainEntry[];
+  changed: boolean;
+}
+
+function normalizeEntries(raw: unknown): NormalizeResult {
+  if (!Array.isArray(raw)) {
+    return { entries: [], changed: raw !== undefined };
+  }
+
+  const now = Date.now();
+  const defaultApprovedAt = new Date(now).toISOString();
+  const defaultExpiresAt = new Date(now + CONSENT_TTL_MS).toISOString();
+  const deduped = new Map<string, ApprovedDomainEntry>();
+  let changed = false;
+
+  for (const item of raw) {
+    let entry: ApprovedDomainEntry | null = null;
+
+    // Backward compatibility: legacy format was string[]
+    if (typeof item === 'string' && item.length > 0) {
+      changed = true;
+      entry = {
+        domain: item,
+        approvedAt: defaultApprovedAt,
+        expiresAt: defaultExpiresAt,
+      };
+    } else if (item && typeof item === 'object' && typeof (item as any).domain === 'string') {
+      const domain = (item as any).domain as string;
+      if (domain.length === 0) {
+        changed = true;
+        continue;
+      }
+      const hasApprovedAt = isValidIsoDate((item as any).approvedAt);
+      const approvedAt = hasApprovedAt
+        ? (item as any).approvedAt
+        : defaultApprovedAt;
+      const hasExpiresAt = isValidIsoDate((item as any).expiresAt);
+      const expiresAt = hasExpiresAt
+        ? (item as any).expiresAt
+        : new Date(Date.parse(approvedAt) + CONSENT_TTL_MS).toISOString();
+      if (!hasApprovedAt || !hasExpiresAt) changed = true;
+      entry = { domain, approvedAt, expiresAt };
+    } else {
+      changed = true;
+    }
+
+    if (!entry) continue;
+    const existing = deduped.get(entry.domain);
+    if (!existing) {
+      deduped.set(entry.domain, entry);
+      continue;
+    }
+    changed = true;
+    if (Date.parse(entry.expiresAt) > Date.parse(existing.expiresAt)) {
+      deduped.set(entry.domain, entry);
+    }
+  }
+
+  if (deduped.size !== raw.length) changed = true;
+  return { entries: [...deduped.values()], changed };
+}
+
+function isExpired(entry: ApprovedDomainEntry, nowMs: number): boolean {
+  return Date.parse(entry.expiresAt) <= nowMs;
+}
+
+function getStorageEntries(): Promise<NormalizeResult> {
   return new Promise((resolve) => {
     chrome.storage.local.get([STORAGE_KEY], (result) => {
-      resolve(result[STORAGE_KEY] ?? []);
+      resolve(normalizeEntries(result[STORAGE_KEY]));
     });
   });
 }
 
-function setStorage(domains: string[]): Promise<void> {
+function setStorageEntries(entries: ApprovedDomainEntry[]): Promise<void> {
   return new Promise((resolve) => {
-    chrome.storage.local.set({ [STORAGE_KEY]: domains }, resolve);
+    chrome.storage.local.set({ [STORAGE_KEY]: entries }, resolve);
   });
 }
 
+async function getActiveEntries(): Promise<ApprovedDomainEntry[]> {
+  const normalized = await getStorageEntries();
+  const entries = normalized.entries;
+  const nowMs = Date.now();
+  const active = entries.filter(entry => !isExpired(entry, nowMs));
+  if (normalized.changed || active.length !== entries.length) {
+    await setStorageEntries(active);
+  }
+  return active;
+}
+
 export async function isApproved(domain: string): Promise<boolean> {
-  const domains = await getStorage();
-  return domains.includes(domain);
+  const entries = await getActiveEntries();
+  return entries.some(entry => entry.domain === domain);
 }
 
 export async function addApprovedDomain(domain: string): Promise<void> {
-  const domains = await getStorage();
-  if (!domains.includes(domain)) {
-    domains.push(domain);
-    await setStorage(domains);
+  const entries = await getActiveEntries();
+  const now = Date.now();
+  const updated: ApprovedDomainEntry = {
+    domain,
+    approvedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + CONSENT_TTL_MS).toISOString(),
+  };
+
+  const existingIndex = entries.findIndex(entry => entry.domain === domain);
+  if (existingIndex >= 0) {
+    entries[existingIndex] = updated;
+  } else {
+    entries.push(updated);
   }
+
+  await setStorageEntries(entries);
 }
 
 export async function removeApprovedDomain(domain: string): Promise<void> {
-  const domains = await getStorage();
-  await setStorage(domains.filter(d => d !== domain));
+  const entries = await getActiveEntries();
+  await setStorageEntries(entries.filter(entry => entry.domain !== domain));
 }
 
 export async function getApprovedDomains(): Promise<string[]> {
-  return getStorage();
+  const entries = await getActiveEntries();
+  return entries.map(entry => entry.domain);
+}
+
+export async function getApprovedDomainEntries(): Promise<ApprovedDomainEntry[]> {
+  const entries = await getActiveEntries();
+  return [...entries].sort((a, b) => Date.parse(b.approvedAt) - Date.parse(a.approvedAt));
 }

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -262,6 +262,83 @@ chrome.storage.local.get(['excludedDomains'], (result) => {
   renderExcludedDomains(result.excludedDomains ?? []);
 });
 
+// --- Approved-domain consent list ---
+
+interface ApprovedDomainEntry {
+  domain: string;
+  approvedAt: string;
+  expiresAt: string;
+}
+
+function formatTimeAgo(iso: string): string {
+  const deltaMs = Date.now() - Date.parse(iso);
+  if (!Number.isFinite(deltaMs)) return 'unknown';
+  const sec = Math.floor(deltaMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  return `${days}d ago`;
+}
+
+function formatExpiry(iso: string): string {
+  const deltaMs = Date.parse(iso) - Date.now();
+  if (!Number.isFinite(deltaMs)) return 'unknown';
+  if (deltaMs <= 0) return 'expired';
+  const min = Math.floor(deltaMs / (60 * 1000));
+  if (min < 60) return `expires in ${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `expires in ${hr}h`;
+  const days = Math.floor(hr / 24);
+  return `expires in ${days}d`;
+}
+
+function renderApprovedDomains(entries: ApprovedDomainEntry[]) {
+  const list = document.getElementById('approved-domains-list')!;
+  while (list.firstChild) list.removeChild(list.firstChild);
+  if (entries.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'current-site-empty';
+    empty.textContent = 'No active approvals.';
+    list.appendChild(empty);
+    return;
+  }
+  for (const entry of entries) {
+    const item = document.createElement('div');
+    item.className = 'excluded-item';
+
+    const left = document.createElement('div');
+    const domain = document.createElement('div');
+    domain.textContent = entry.domain;
+    const meta = document.createElement('div');
+    meta.className = 'index-meta';
+    meta.textContent = `approved ${formatTimeAgo(entry.approvedAt)} · ${formatExpiry(entry.expiresAt)}`;
+    left.appendChild(domain);
+    left.appendChild(meta);
+
+    const btn = document.createElement('button');
+    btn.className = 'btn-remove';
+    btn.textContent = '×';
+    btn.title = 'Revoke approval';
+    btn.addEventListener('click', () => {
+      chrome.runtime.sendMessage({ type: 'REMOVE_APPROVED_DOMAIN', domain: entry.domain }, (response: any) => {
+        const approved = response?.approvedDomains as ApprovedDomainEntry[] | undefined;
+        renderApprovedDomains(approved ?? []);
+      });
+    });
+
+    item.appendChild(left);
+    item.appendChild(btn);
+    list.appendChild(item);
+  }
+}
+
+chrome.runtime.sendMessage({ type: 'GET_APPROVED_DOMAINS' }, (response: any) => {
+  renderApprovedDomains((response?.approvedDomains ?? []) as ApprovedDomainEntry[]);
+});
+
 document.getElementById('btn-exclude-domain')!.addEventListener('click', () => {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     const tab = tabs[0];

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -12,7 +12,7 @@ export interface CaptureState {
 // Messages from popup → background
 export interface CaptureMessage {
   type: 'START_CAPTURE' | 'STOP_CAPTURE' | 'GET_STATE' | 'DOWNLOAD_SKILL'
-    | 'PROMOTE_DOMAIN' | 'GET_INDEX';
+    | 'PROMOTE_DOMAIN' | 'GET_INDEX' | 'GET_APPROVED_DOMAINS' | 'REMOVE_APPROVED_DOMAIN';
   domain?: string; // for PROMOTE_DOMAIN
 }
 

--- a/test/extension/consent.test.ts
+++ b/test/extension/consent.test.ts
@@ -22,7 +22,13 @@ const mockStorage: Record<string, any> = {};
 };
 
 // Import after mock is set up
-const { isApproved, addApprovedDomain, removeApprovedDomain, getApprovedDomains } = await import('../../extension/src/consent.js');
+const {
+  isApproved,
+  addApprovedDomain,
+  removeApprovedDomain,
+  getApprovedDomains,
+  getApprovedDomainEntries,
+} = await import('../../extension/src/consent.js');
 
 describe('consent management', () => {
   beforeEach(() => {
@@ -54,5 +60,30 @@ describe('consent management', () => {
     await addApprovedDomain('discord.com');
     const domains = await getApprovedDomains();
     assert.equal(domains.length, 1);
+  });
+
+  it('stores approval metadata with timestamps', async () => {
+    await addApprovedDomain('discord.com');
+    const entries = await getApprovedDomainEntries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].domain, 'discord.com');
+    assert.ok(typeof entries[0].approvedAt === 'string');
+    assert.ok(typeof entries[0].expiresAt === 'string');
+    assert.ok(Date.parse(entries[0].expiresAt) > Date.parse(entries[0].approvedAt));
+  });
+
+  it('migrates legacy string[] storage and filters expired entries', async () => {
+    const expired = new Date(Date.now() - 60_000).toISOString();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    mockStorage.approvedAgentDomains = [
+      'legacy.com',
+      { domain: 'fresh.com', approvedAt: new Date().toISOString(), expiresAt: future },
+      { domain: 'expired.com', approvedAt: new Date().toISOString(), expiresAt: expired },
+    ];
+
+    const domains = await getApprovedDomains();
+    assert.ok(domains.includes('legacy.com'));
+    assert.ok(domains.includes('fresh.com'));
+    assert.ok(!domains.includes('expired.com'));
   });
 });


### PR DESCRIPTION
## Summary
- add 24h TTL consent entries with approvedAt/expiresAt metadata
- migrate legacy approvedAgentDomains string arrays and prune expired approvals on read
- add popup Settings section to list approved domains and revoke approvals
- add extension message handlers/types for listing and removing approvals
- add regression tests for metadata storage, legacy migration, and expiry behavior

## Security context
Fixes #20.

## Validation
- npm run -s typecheck
- npm test