### PR TITLE
fix(skill): add signedAt freshness checks for replay protection

### DIFF
--- a/src/skill/signing.ts
+++ b/src/skill/signing.ts
@@ -35,10 +35,12 @@ function sortKeysDeep(value: unknown): unknown {
  * Sign a skill file. Returns a new object with signature and provenance: 'self'.
  */
 export function signSkillFile(skill: SkillFile, key: Buffer): SkillFile {
-  const payload = canonicalize(skill);
+  const signedAt = new Date().toISOString();
+  const payload = canonicalize({ ...skill, signedAt } as SkillFile);
   const signature = hmacSign(payload, key);
   return {
     ...skill,
+    signedAt,
     provenance: 'self',
     signature,
   };
@@ -53,9 +55,10 @@ export function signSkillFileAs(
   key: Buffer,
   provenance: 'self' | 'imported-signed',
 ): SkillFile {
-  const payload = canonicalize(skill);
+  const signedAt = new Date().toISOString();
+  const payload = canonicalize({ ...skill, signedAt } as SkillFile);
   const signature = hmacSign(payload, key);
-  return { ...skill, provenance, signature };
+  return { ...skill, signedAt, provenance, signature };
 }
 
 /**

--- a/src/skill/store.ts
+++ b/src/skill/store.ts
@@ -13,6 +13,8 @@ auth.enc
 *.key
 `;
 
+const MAX_SIGNATURE_AGE_DAYS = 180;
+
 function skillPath(domain: string, skillsDir: string): string {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(domain)) {
     throw new Error(`Invalid domain: ${domain}`);
@@ -124,6 +126,20 @@ export async function readSkillFile(
         }
         if (!verified) {
           throw new Error(`Skill file signature verification failed for ${domain} — file may be tampered`);
+        }
+
+        if (skill.signedAt) {
+          const signedAtMs = Date.parse(skill.signedAt);
+          if (!Number.isNaN(signedAtMs)) {
+            const ageMs = Date.now() - signedAtMs;
+            const maxAgeMs = MAX_SIGNATURE_AGE_DAYS * 24 * 60 * 60 * 1000;
+            if (ageMs > maxAgeMs) {
+              throw new Error(
+                `Skill file signature is stale for ${domain} (signed ${skill.signedAt}). ` +
+                `Re-capture or re-import to refresh signature.`
+              );
+            }
+          }
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,8 @@ export interface SkillFile {
   version: string;
   domain: string;
   capturedAt: string;
+  /** Signature timestamp (ISO) used for anti-replay staleness checks */
+  signedAt?: string;
   baseUrl: string;
   endpoints: SkillEndpoint[];
   metadata: {

--- a/test/skill/signing.test.ts
+++ b/test/skill/signing.test.ts
@@ -36,6 +36,7 @@ describe('skill file signing', () => {
     const signed = signSkillFile(skill, key);
 
     assert.equal(signed.provenance, 'self');
+    assert.ok(typeof signed.signedAt === 'string');
     assert.ok(signed.signature?.startsWith('hmac-sha256:'));
   });
 

--- a/test/skill/store.test.ts
+++ b/test/skill/store.test.ts
@@ -1,11 +1,14 @@
 // test/skill/store.test.ts
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { writeSkillFile, readSkillFile, listSkillFiles } from '../../src/skill/store.js';
 import type { SkillFile } from '../../src/types.js';
+import { randomBytes } from 'node:crypto';
+import { canonicalize } from '../../src/skill/signing.js';
+import { hmacSign } from '../../src/auth/crypto.js';
 
 const makeSkill = (domain: string): SkillFile => ({
   version: '1.1',
@@ -98,5 +101,25 @@ describe('skill store', () => {
 
     const gitignore = await rf(join(baseDir, '.gitignore'), 'utf-8');
     assert.equal(gitignore, 'custom content\n');
+  });
+
+  it('rejects stale signed skill files', async () => {
+    const signingKey = randomBytes(32);
+    const staleBase = {
+      ...makeSkill('example.com'),
+      provenance: 'self' as const,
+      signedAt: '2020-01-01T00:00:00.000Z',
+    };
+    const stale = {
+      ...staleBase,
+      signature: hmacSign(canonicalize(staleBase as SkillFile), signingKey),
+    };
+    const filePath = join(testDir, 'example.com.json');
+    await writeFile(filePath, JSON.stringify(stale, null, 2));
+
+    await assert.rejects(
+      () => readSkillFile('example.com', testDir, { verifySignature: true, signingKey }),
+      /signature is stale/i,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add optional signedAt to SkillFile and stamp it when signing
- include signedAt in canonical signed payload to prevent timestamp tampering
- reject verified signed skill files older than 180 days to reduce replay window
- add regression tests for signedAt emission and stale-signature rejection

## Security context
Fixes #19.

## Validation
- npm run -s typecheck
- node --import tsx --test test/skill/signing.test.ts test/skill/store.test.ts test/skill/signing-enforcement.test.ts test/skill/store-verify.test.ts
- npm test