### PR TITLE
fix(extension): close scrubbing gap and make passive indexing opt-in

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -59,6 +59,13 @@
     <div id="tab-settings" class="tab-content hidden">
       <div class="setting-row">
         <label>
+          <input type="checkbox" id="passive-index-toggle">
+          Passive indexing
+        </label>
+        <p class="setting-desc">Observe API metadata in the background across sites. Off by default.</p>
+      </div>
+      <div class="setting-row">
+        <label>
           <input type="checkbox" id="auto-learn-toggle">
           Auto-learn mode
         </label>

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -12,6 +12,11 @@ import { mergeObservation, createEmptyIndex } from './index-store.js';
 import { markPromoted } from './promotion.js';
 import { applyLifecycle } from './lifecycle.js';
 import { encrypt, decrypt } from './crypto.js';
+import {
+  PASSIVE_INDEX_DEFAULT_ENABLED,
+  resolvePassiveIndexEnabled,
+  canObservePassiveIndex,
+} from './passive-index-settings.js';
 import type { IndexFile, IndexEntry } from './types.js';
 
 // --- Native messaging bridge (persistent port) ---
@@ -626,6 +631,7 @@ chrome.storage.session.get(['captureState', 'lastSkillJson'], (result) => {
 
 let passiveIndex: IndexFile = createEmptyIndex();
 let indexDirty = false; // tracks whether index has unsaved changes
+let passiveIndexEnabled = PASSIVE_INDEX_DEFAULT_ENABLED;
 
 // --- Excluded domains (cached in memory, synced from chrome.storage.local) ---
 let excludedDomains: Set<string> = new Set();
@@ -634,9 +640,16 @@ chrome.storage.local.get(['excludedDomains'], (result) => {
   excludedDomains = new Set(result.excludedDomains ?? []);
 });
 
+chrome.storage.local.get(['passiveIndexEnabled'], (result) => {
+  passiveIndexEnabled = resolvePassiveIndexEnabled(result.passiveIndexEnabled);
+});
+
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area === 'local' && changes.excludedDomains) {
     excludedDomains = new Set(changes.excludedDomains.newValue ?? []);
+  }
+  if (area === 'local' && changes.passiveIndexEnabled) {
+    passiveIndexEnabled = resolvePassiveIndexEnabled(changes.passiveIndexEnabled.newValue);
   }
 });
 
@@ -657,7 +670,7 @@ chrome.storage.local.get(['passiveIndex'], (result) => {
 // Capture request headers (for auth detection) — fires before request is sent
 chrome.webRequest.onSendHeaders.addListener(
   (details) => {
-    if (details.tabId < 0) return; // ignore non-tab requests
+    if (!canObservePassiveIndex(passiveIndexEnabled, details.tabId)) return;
     const headers: Record<string, string> = {};
     for (const h of details.requestHeaders ?? []) {
       if (h.name && h.value) headers[h.name.toLowerCase()] = h.value;
@@ -682,7 +695,7 @@ chrome.webRequest.onSendHeaders.addListener(
 // Process completed requests — this is the main observation point
 chrome.webRequest.onCompleted.addListener(
   (details) => {
-    if (details.tabId < 0) return; // ignore non-tab requests
+    if (!canObservePassiveIndex(passiveIndexEnabled, details.tabId)) return;
 
     // Check exclusion list
     try {
@@ -1177,6 +1190,22 @@ chrome.runtime.onMessage.addListener(
       case 'GET_INDEX': {
         sendResponse({ type: 'STATE_UPDATE', index: passiveIndex } as any);
         break;
+      }
+
+      case 'GET_PASSIVE_INDEX_STATUS': {
+        sendResponse({ type: 'STATE_UPDATE', passiveIndexEnabled } as any);
+        break;
+      }
+
+      case 'SET_PASSIVE_INDEX_ENABLED': {
+        const enabled = message.enabled === true;
+        passiveIndexEnabled = enabled;
+        chrome.storage.local.set({ passiveIndexEnabled: enabled }).then(() => {
+          sendResponse({ type: 'STATE_UPDATE', passiveIndexEnabled } as any);
+        }).catch((err) => {
+          sendResponse({ type: 'ERROR', error: String(err) } as CaptureResponse);
+        });
+        return true;
       }
 
       case 'GET_APPROVED_DOMAINS': {

--- a/extension/src/passive-index-settings.ts
+++ b/extension/src/passive-index-settings.ts
@@ -1,0 +1,9 @@
+export const PASSIVE_INDEX_DEFAULT_ENABLED = false;
+
+export function resolvePassiveIndexEnabled(value: unknown): boolean {
+  return value === true;
+}
+
+export function canObservePassiveIndex(passiveIndexEnabled: boolean, tabId: number): boolean {
+  return passiveIndexEnabled && tabId >= 0;
+}

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -221,6 +221,19 @@ autolearnCaptureToggle.addEventListener('change', (e) => {
 
 // --- Settings tab ---
 
+const passiveIndexToggle = document.getElementById('passive-index-toggle') as HTMLInputElement;
+
+chrome.runtime.sendMessage({ type: 'GET_PASSIVE_INDEX_STATUS' }, (response: any) => {
+  passiveIndexToggle.checked = response?.passiveIndexEnabled === true;
+});
+
+passiveIndexToggle.addEventListener('change', (e) => {
+  const enabled = (e.target as HTMLInputElement).checked;
+  chrome.runtime.sendMessage({ type: 'SET_PASSIVE_INDEX_ENABLED', enabled }, (response: any) => {
+    passiveIndexToggle.checked = response?.passiveIndexEnabled === true;
+  });
+});
+
 chrome.storage.local.get(['autoLearn', 'revisitThreshold'], (result) => {
   (document.getElementById('auto-learn-toggle') as HTMLInputElement).checked = result.autoLearn ?? false;
   (document.getElementById('revisit-threshold') as HTMLInputElement).value = String(result.revisitThreshold ?? 3);

--- a/extension/src/security.ts
+++ b/extension/src/security.ts
@@ -77,6 +77,14 @@ function scrubObjectFields(obj: Record<string, unknown>): void {
   }
 }
 
+function scrubHeaderFields(headers: Record<string, unknown>): void {
+  for (const key of Object.keys(headers)) {
+    if (SENSITIVE_HEADERS.has(key.toLowerCase()) && typeof headers[key] === 'string') {
+      headers[key] = '[stored]';
+    }
+  }
+}
+
 export function scrubAuthFromSkillJson(json: string): string {
   let skill: any;
   try {
@@ -87,20 +95,19 @@ export function scrubAuthFromSkillJson(json: string): string {
   if (Array.isArray(skill.endpoints)) {
     for (const ep of skill.endpoints) {
       if (ep.headers && typeof ep.headers === 'object') {
-        for (const key of Object.keys(ep.headers)) {
-          if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
-            ep.headers[key] = '[stored]';
-          }
-        }
+        scrubHeaderFields(ep.headers);
       }
-      // Also scrub from example request headers if present
+
+      // Also scrub from schema-aligned example request headers.
+      if (ep.examples?.request?.headers && typeof ep.examples.request.headers === 'object') {
+        scrubHeaderFields(ep.examples.request.headers);
+      }
+
+      // Backward-compat for older extension-generated shape.
       if (ep.exampleRequestHeaders && typeof ep.exampleRequestHeaders === 'object') {
-        for (const key of Object.keys(ep.exampleRequestHeaders)) {
-          if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
-            ep.exampleRequestHeaders[key] = '[stored]';
-          }
-        }
+        scrubHeaderFields(ep.exampleRequestHeaders);
       }
+
       // Scrub sensitive fields from request body templates
       if (ep.requestBody?.template && typeof ep.requestBody.template === 'object') {
         scrubObjectFields(ep.requestBody.template);

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -12,8 +12,10 @@ export interface CaptureState {
 // Messages from popup → background
 export interface CaptureMessage {
   type: 'START_CAPTURE' | 'STOP_CAPTURE' | 'GET_STATE' | 'DOWNLOAD_SKILL'
-    | 'PROMOTE_DOMAIN' | 'GET_INDEX' | 'GET_APPROVED_DOMAINS' | 'REMOVE_APPROVED_DOMAIN';
+    | 'PROMOTE_DOMAIN' | 'GET_INDEX' | 'GET_APPROVED_DOMAINS' | 'REMOVE_APPROVED_DOMAIN'
+    | 'GET_PASSIVE_INDEX_STATUS' | 'SET_PASSIVE_INDEX_ENABLED';
   domain?: string; // for PROMOTE_DOMAIN
+  enabled?: boolean; // for SET_PASSIVE_INDEX_ENABLED
 }
 
 // Responses from background → popup

--- a/test/extension/passive-index-settings.test.ts
+++ b/test/extension/passive-index-settings.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PASSIVE_INDEX_DEFAULT_ENABLED,
+  resolvePassiveIndexEnabled,
+  canObservePassiveIndex,
+} from '../../extension/src/passive-index-settings.js';
+
+describe('passive index settings', () => {
+  it('defaults passive indexing to disabled', () => {
+    assert.equal(PASSIVE_INDEX_DEFAULT_ENABLED, false);
+    assert.equal(resolvePassiveIndexEnabled(undefined), false);
+    assert.equal(resolvePassiveIndexEnabled(null), false);
+    assert.equal(resolvePassiveIndexEnabled(false), false);
+  });
+
+  it('enables passive indexing only for explicit true', () => {
+    assert.equal(resolvePassiveIndexEnabled(true), true);
+    assert.equal(resolvePassiveIndexEnabled('true'), false);
+    assert.equal(resolvePassiveIndexEnabled(1), false);
+  });
+
+  it('requires enabled flag and tab context for observation', () => {
+    assert.equal(canObservePassiveIndex(true, 10), true);
+    assert.equal(canObservePassiveIndex(true, -1), false);
+    assert.equal(canObservePassiveIndex(false, 10), false);
+  });
+});

--- a/test/extension/security.test.ts
+++ b/test/extension/security.test.ts
@@ -121,4 +121,38 @@ describe('auth scrubbing from exported skill JSON', () => {
     assert.equal(scrubbed.endpoints[0].headers['content-type'], 'application/json');
     assert.equal(scrubbed.endpoints[0].headers.accept, '*/*');
   });
+
+  it('replaces sensitive values in examples.request.headers', () => {
+    const input = JSON.stringify({
+      endpoints: [{
+        examples: {
+          request: {
+            headers: {
+              authorization: 'Bearer live-token',
+              cookie: 'session=live-secret',
+              accept: 'application/json',
+            },
+          },
+        },
+      }],
+    });
+    const scrubbed = JSON.parse(scrubAuthFromSkillJson(input));
+    assert.equal(scrubbed.endpoints[0].examples.request.headers.authorization, '[stored]');
+    assert.equal(scrubbed.endpoints[0].examples.request.headers.cookie, '[stored]');
+    assert.equal(scrubbed.endpoints[0].examples.request.headers.accept, 'application/json');
+  });
+
+  it('still scrubs legacy exampleRequestHeaders for backward compatibility', () => {
+    const input = JSON.stringify({
+      endpoints: [{
+        exampleRequestHeaders: {
+          authorization: 'Bearer legacy-live-token',
+          'x-api-key': 'legacy-secret',
+        },
+      }],
+    });
+    const scrubbed = JSON.parse(scrubAuthFromSkillJson(input));
+    assert.equal(scrubbed.endpoints[0].exampleRequestHeaders.authorization, '[stored]');
+    assert.equal(scrubbed.endpoints[0].exampleRequestHeaders['x-api-key'], '[stored]');
+  });
 });


### PR DESCRIPTION
## Summary
- fix extension export sanitization to scrub auth headers from schema-aligned examples.request.headers
- keep backward compatibility by continuing to scrub legacy exampleRequestHeaders
- add explicit passive-indexing opt-in gate (passiveIndexEnabled) for background webRequest observation
- default passive indexing to disabled and add Settings toggle in popup
- add regression tests for scrubbing coverage and passive-index settings behavior

## Security/privacy context
Addresses the two follow-up medium findings from the audit:
1. export scrubbing path mismatch (exampleRequestHeaders vs examples.request.headers)
2. passive indexing always-on local metadata persistence by default

## Validation
- npm run -s typecheck
- node --import tsx --test test/extension/security.test.ts test/extension/passive-index-settings.test.ts test/extension/consent.test.ts
- npm test