### PR TITLE
fix(github): hybrid org scan — code search + name-heuristic probe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apitap/core",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Intercept web API traffic during browsing. Generate portable skill files so AI agents can call APIs directly instead of scraping.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/skill/github.ts
+++ b/src/skill/github.ts
@@ -250,14 +250,25 @@ export function filterResults(
   return { passed, skips };
 }
 
-// ─── Org Scan — Code Search ───────────────────────────────────────────────────
+// ─── Org Scan — Hybrid: Code Search + Name-Heuristic Probe ───────────────────
 
 export const SPEC_FILENAMES = ['openapi.json', 'openapi.yaml', 'swagger.json', 'swagger.yaml'];
 
+// Repo name patterns that likely contain OpenAPI specs
+const SPEC_REPO_PATTERNS = /(?:api-spec|api-schema|openapi|swagger|rest-api|api-schemas|openapi-spec)/i;
+
+// Max repo pages to fetch for name-heuristic scan (100 repos/page)
+const MAX_REPO_PAGES = 3;
+
 /**
- * Uses GitHub's Code Search API to find OpenAPI spec files across an org's repos.
- * Queries run sequentially — GitHub's code search has a secondary rate limit of
- * 30 req/min (authenticated). Parallel fan-out risks immediate 403.
+ * Hybrid org scan: code search results UNION name-heuristic matches.
+ *
+ * Code search (GitHub /search/code) is unreliable — GitHub doesn't index all
+ * files, so repos like cloudflare/api-schemas are invisible to it. The
+ * name-heuristic pass lists the org's repos (sorted by stars, capped at 300)
+ * and probes repos whose names match API-spec patterns for spec files.
+ *
+ * Both sources dedup by htmlUrl before returning.
  */
 export async function searchOrgSpecs(
   org: string,
@@ -266,6 +277,7 @@ export async function searchOrgSpecs(
   const allItems: GitHubSpecResult[] = [];
   const seen = new Set<string>();
 
+  // ── Phase 1: Code search (may return sparse results) ──────────────────────
   // Sequential queries — GitHub's code search has a secondary rate limit
   // of 30 req/min (authenticated). Parallel fan-out risks immediate 403.
   for (const filename of SPEC_FILENAMES) {
@@ -277,6 +289,9 @@ export async function searchOrgSpecs(
       if (err.status === 422) {
         throw new Error(`GitHub org '${org}' not found.`);
       }
+      // Code search rate limit or other transient error — continue to
+      // name-heuristic phase rather than failing entirely.
+      if (err.status === 403 || err.status === 429) break;
       throw err;
     }
 
@@ -299,6 +314,55 @@ export async function searchOrgSpecs(
         pushedAt: repo.pushed_at ?? '',
         description: repo.description ?? '',
       });
+    }
+  }
+
+  // ── Phase 2: Name-heuristic probe ─────────────────────────────────────────
+  // List org repos (sorted by stars, up to 300), find those whose names
+  // match API-spec patterns, probe each for spec files via contents API.
+  const probed = new Set<string>(); // repos already found by code search
+  for (const item of allItems) probed.add(item.repoFullName);
+
+  for (let page = 1; page <= MAX_REPO_PAGES; page++) {
+    let repos;
+    try {
+      const { data } = await githubFetch(
+        `/orgs/${org}/repos?per_page=100&sort=stars&direction=desc&page=${page}`,
+        token,
+      );
+      repos = data;
+    } catch {
+      break; // org listing failed — we already have code search results
+    }
+
+    if (!Array.isArray(repos) || repos.length === 0) break;
+
+    for (const repo of repos) {
+      const fullName: string = repo.full_name;
+      if (probed.has(fullName)) continue;
+
+      if (!SPEC_REPO_PATTERNS.test(repo.name)) continue;
+      probed.add(fullName);
+
+      const specs = await probeForSpecs(repo.owner?.login ?? org, repo.name, token);
+      for (const spec of specs) {
+        if (seen.has(spec.htmlUrl)) continue;
+        seen.add(spec.htmlUrl);
+
+        allItems.push({
+          owner: repo.owner?.login ?? org,
+          repo: repo.name,
+          repoFullName: fullName,
+          filePath: spec.path,
+          htmlUrl: spec.htmlUrl,
+          specUrl: `https://raw.githubusercontent.com/${fullName}/${repo.default_branch ?? 'main'}/${spec.path}`,
+          stars: repo.stargazers_count ?? 0,
+          isFork: repo.fork ?? false,
+          isArchived: repo.archived ?? false,
+          pushedAt: repo.pushed_at ?? '',
+          description: repo.description ?? '',
+        });
+      }
     }
   }
 

--- a/test/skill/github.test.ts
+++ b/test/skill/github.test.ts
@@ -726,46 +726,81 @@ describe('searchOrgSpecs', () => {
     globalThis.fetch = origFetch;
   });
 
+  // Helper: URL-aware fetch mock that returns empty org repos for the heuristic phase
+  function makeOrgAwareFetch(codeSearchResponses: Response[]) {
+    let codeSearchIndex = 0;
+    return async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      // Code search queries
+      if (url.includes('/search/code')) {
+        return codeSearchResponses[codeSearchIndex++] ?? makeCodeSearchResponse([]);
+      }
+      // Org repos listing (heuristic phase) — return empty
+      if (url.includes('/orgs/') && url.includes('/repos')) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'x-ratelimit-remaining': '100', 'x-ratelimit-limit': '5000', 'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600) },
+        });
+      }
+      // Contents probe — return empty array
+      if (url.includes('/contents')) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'x-ratelimit-remaining': '100', 'x-ratelimit-limit': '5000', 'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600) },
+        });
+      }
+      return makeCodeSearchResponse([]);
+    };
+  }
+
   it('queries 4 filename patterns and deduplicates by htmlUrl', async () => {
     const capturedUrls: string[] = [];
 
     // Return one item per query, but make the openapi.yaml item share an htmlUrl
     // with the openapi.json item to verify dedup.
     const sharedHtmlUrl = 'https://github.com/acme/api-spec/blob/main/openapi.json';
-    const callResponses = [
-      // openapi.json → 1 item
+    const codeSearchResponses = [
       makeCodeSearchResponse([
         makeCodeSearchItem({ htmlUrl: sharedHtmlUrl, path: 'openapi.json' }),
       ]),
-      // openapi.yaml → 1 item with the SAME htmlUrl (simulate duplicate)
       makeCodeSearchResponse([
         makeCodeSearchItem({ htmlUrl: sharedHtmlUrl, path: 'openapi.json' }),
       ]),
-      // swagger.json → 1 fresh item
       makeCodeSearchResponse([
         makeCodeSearchItem({
           htmlUrl: 'https://github.com/acme/api-spec/blob/main/swagger.json',
           path: 'swagger.json',
         }),
       ]),
-      // swagger.yaml → empty
       makeCodeSearchResponse([]),
     ];
-    let callIndex = 0;
+    let codeSearchIndex = 0;
 
     globalThis.fetch = async (input: RequestInfo | URL) => {
-      capturedUrls.push(input.toString());
-      return callResponses[callIndex++];
+      const url = input.toString();
+      capturedUrls.push(url);
+      if (url.includes('/search/code')) {
+        return codeSearchResponses[codeSearchIndex++] ?? makeCodeSearchResponse([]);
+      }
+      // Org repos listing — return empty (no heuristic matches)
+      if (url.includes('/orgs/') && url.includes('/repos')) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'x-ratelimit-remaining': '100', 'x-ratelimit-limit': '5000', 'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600) },
+        });
+      }
+      return makeCodeSearchResponse([]);
     };
 
     const results = await github.searchOrgSpecs('acme', 'tok');
 
-    // 4 queries should have been made
-    assert.strictEqual(capturedUrls.length, 4);
-    assert.ok(capturedUrls[0].includes('filename%3Aopenapi.json'), `q0: ${capturedUrls[0]}`);
-    assert.ok(capturedUrls[1].includes('filename%3Aopenapi.yaml'), `q1: ${capturedUrls[1]}`);
-    assert.ok(capturedUrls[2].includes('filename%3Aswagger.json'), `q2: ${capturedUrls[2]}`);
-    assert.ok(capturedUrls[3].includes('filename%3Aswagger.yaml'), `q3: ${capturedUrls[3]}`);
+    // 4 code search queries should have been made
+    const codeSearchUrls = capturedUrls.filter(u => u.includes('/search/code'));
+    assert.strictEqual(codeSearchUrls.length, 4);
+    assert.ok(codeSearchUrls[0].includes('filename%3Aopenapi.json'), `q0: ${codeSearchUrls[0]}`);
+    assert.ok(codeSearchUrls[1].includes('filename%3Aopenapi.yaml'), `q1: ${codeSearchUrls[1]}`);
+    assert.ok(codeSearchUrls[2].includes('filename%3Aswagger.json'), `q2: ${codeSearchUrls[2]}`);
+    assert.ok(codeSearchUrls[3].includes('filename%3Aswagger.yaml'), `q3: ${codeSearchUrls[3]}`);
 
     // Dedup: 2 items with sharedHtmlUrl → 1, plus the swagger.json → total 2
     assert.strictEqual(results.length, 2);
@@ -774,8 +809,6 @@ describe('searchOrgSpecs', () => {
   });
 
   it('ranks by stars descending then path depth ascending', async () => {
-    // Returns items in a shuffled order: low-stars-shallow, high-stars-deep,
-    // high-stars-shallow, low-stars-deep — expect sorted: high-stars-shallow first.
     const items = [
       makeCodeSearchItem({
         htmlUrl: 'https://github.com/acme/low-stars-shallow/blob/main/openapi.json',
@@ -802,11 +835,7 @@ describe('searchOrgSpecs', () => {
         stars: 10,
       }),
     ];
-    let callIndex = 0;
-    globalThis.fetch = async () => {
-      // Return all items on the first call, empty for remaining 3
-      return callIndex++ === 0 ? makeCodeSearchResponse(items) : makeCodeSearchResponse([]);
-    };
+    globalThis.fetch = makeOrgAwareFetch([makeCodeSearchResponse(items)]);
 
     const results = await github.searchOrgSpecs('acme', 'tok');
 
@@ -839,9 +868,7 @@ describe('searchOrgSpecs', () => {
       ownerLogin: 'cloudflare',
     });
 
-    let callIndex = 0;
-    globalThis.fetch = async () =>
-      callIndex++ === 0 ? makeCodeSearchResponse([item]) : makeCodeSearchResponse([]);
+    globalThis.fetch = makeOrgAwareFetch([makeCodeSearchResponse([item])]);
 
     const results = await github.searchOrgSpecs('cloudflare', 'tok');
 
@@ -889,12 +916,123 @@ describe('searchOrgSpecs', () => {
   });
 
   it('returns empty array when no specs found', async () => {
-    globalThis.fetch = async () => makeCodeSearchResponse([]);
+    globalThis.fetch = makeOrgAwareFetch([]);
 
     const results = await github.searchOrgSpecs('empty-org', 'tok');
 
     assert.strictEqual(results.length, 0);
     assert.ok(Array.isArray(results));
+  });
+
+  it('finds specs via name-heuristic when code search returns nothing', async () => {
+    // Code search returns nothing, but org has a repo named "api-schemas"
+    // with openapi.json at root — name heuristic should find it.
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      // Code search — return empty for all 4 patterns
+      if (url.includes('/search/code')) {
+        return makeCodeSearchResponse([]);
+      }
+
+      // Org repos listing — return one repo matching the name heuristic
+      if (url.includes('/orgs/acme/repos')) {
+        return new Response(JSON.stringify([
+          {
+            name: 'api-schemas',
+            full_name: 'acme/api-schemas',
+            owner: { login: 'acme' },
+            stargazers_count: 160,
+            fork: false,
+            archived: false,
+            pushed_at: '2026-03-01T00:00:00Z',
+            default_branch: 'main',
+            description: 'Public API schemas',
+          },
+        ]), {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'x-ratelimit-remaining': '100', 'x-ratelimit-limit': '5000', 'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600) },
+        });
+      }
+
+      // Contents probe for api-schemas root — has openapi.json
+      if (url.includes('/repos/acme/api-schemas/contents') && !url.includes('/contents/')) {
+        return new Response(JSON.stringify([
+          { name: 'openapi.json', path: 'openapi.json', html_url: 'https://github.com/acme/api-schemas/blob/main/openapi.json' },
+          { name: 'README.md', path: 'README.md', html_url: 'https://github.com/acme/api-schemas/blob/main/README.md' },
+        ]), {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'x-ratelimit-remaining': '100', 'x-ratelimit-limit': '5000', 'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600) },
+        });
+      }
+
+      return makeCodeSearchResponse([]);
+    };
+
+    const results = await github.searchOrgSpecs('acme', 'tok');
+
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].repoFullName, 'acme/api-schemas');
+    assert.strictEqual(results[0].filePath, 'openapi.json');
+    assert.strictEqual(results[0].stars, 160);
+  });
+
+  it('deduplicates between code search and name-heuristic results', async () => {
+    // Code search finds a spec, name heuristic finds the same repo — should dedup
+    const htmlUrl = 'https://github.com/acme/openapi/blob/main/openapi.json';
+
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.includes('/search/code')) {
+        return makeCodeSearchResponse([
+          makeCodeSearchItem({ htmlUrl, path: 'openapi.json', repoFullName: 'acme/openapi' }),
+        ]);
+      }
+
+      if (url.includes('/orgs/acme/repos')) {
+        return new Response(JSON.stringify([
+          { name: 'openapi', full_name: 'acme/openapi', owner: { login: 'acme' }, stargazers_count: 50, fork: false, archived: false, pushed_at: '2026-01-01T00:00:00Z', default_branch: 'main', description: '' },
+        ]), {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'x-ratelimit-remaining': '100', 'x-ratelimit-limit': '5000', 'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600) },
+        });
+      }
+
+      if (url.includes('/repos/acme/openapi/contents')) {
+        return new Response(JSON.stringify([
+          { name: 'openapi.json', path: 'openapi.json', html_url: htmlUrl },
+        ]), {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'x-ratelimit-remaining': '100', 'x-ratelimit-limit': '5000', 'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600) },
+        });
+      }
+
+      return makeCodeSearchResponse([]);
+    };
+
+    const results = await github.searchOrgSpecs('acme', 'tok');
+    assert.strictEqual(results.length, 1, 'Should dedup code search + heuristic results');
+  });
+
+  it('skips repos whose names do not match heuristic patterns', async () => {
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes('/search/code')) return makeCodeSearchResponse([]);
+      if (url.includes('/orgs/acme/repos')) {
+        return new Response(JSON.stringify([
+          { name: 'website', full_name: 'acme/website', owner: { login: 'acme' }, stargazers_count: 5000, fork: false, archived: false, pushed_at: '2026-01-01T00:00:00Z', default_branch: 'main', description: '' },
+          { name: 'docs', full_name: 'acme/docs', owner: { login: 'acme' }, stargazers_count: 3000, fork: false, archived: false, pushed_at: '2026-01-01T00:00:00Z', default_branch: 'main', description: '' },
+        ]), {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'x-ratelimit-remaining': '100', 'x-ratelimit-limit': '5000', 'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600) },
+        });
+      }
+      return makeCodeSearchResponse([]);
+    };
+
+    const results = await github.searchOrgSpecs('acme', 'tok');
+    assert.strictEqual(results.length, 0, 'Non-matching repo names should not be probed');
   });
 });
 


### PR DESCRIPTION
## Summary

- GitHub's Code Search API doesn't reliably index spec files (e.g., `cloudflare/api-schemas` with `openapi.json` at root is invisible to `/search/code`). IRL testing of v1.9.0 revealed this.
- Adds a **name-heuristic fallback** to `searchOrgSpecs()`: after code search, lists the org's repos (up to 300, sorted by stars) and probes repos whose names match patterns (`api-spec`, `api-schema`, `openapi`, `swagger`, `rest-api`, `api-schemas`, `openapi-spec`) for spec files via the contents API
- Code search rate limit errors (403/429) gracefully fall through to the heuristic phase instead of failing the entire scan
- Both sources dedup by `htmlUrl` before returning results

## Test plan
- [x] `npm test` — 1407/1407 tests pass (3 new tests)
- [x] New test: name-heuristic finds specs when code search returns nothing
- [x] New test: dedup between code search and name-heuristic results
- [x] New test: repos not matching heuristic patterns are not probed

🤖 Generated with [Claude Code](https://claude.com/claude-code)