### PR TITLE
Security & privacy audit fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,20 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: this workflow only reads the repo.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # Third-party actions are pinned to a full commit SHA (not a floating
+      # tag) so a tag-hijack/retag cannot inject code into CI.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 22
           cache: npm

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,16 +26,53 @@ If you discover a security vulnerability in ApiTap, please report it responsibly
 ApiTap handles sensitive data (API credentials, request headers, response bodies). Here's how we protect it:
 
 ### Auth Encryption
-Credentials are encrypted at rest using AES-256-GCM with PBKDF2 key derivation, stored at `~/.apitap/auth.enc`. Keys are derived from machine-specific entropy.
+Credentials are encrypted at rest using AES-256-GCM (fresh random IV per
+encryption, authenticated) with a PBKDF2-SHA512 key derived from the machine
+ID and a per-install random salt, stored at `~/.apitap/auth.enc` (mode `0o600`,
+directory `0o700`).
 
-### PII Scrubbing
-During capture, response bodies are scanned for emails, phone numbers, IP addresses, credit card numbers, and SSNs. Detected PII is redacted before writing skill files.
+**Threat model — be precise about what this protects:** the key is derived
+from `/etc/machine-id` (world-readable on most systems) and
+`~/.apitap/install-salt` (stored next to the ciphertext). An attacker who
+obtains *those files* can re-derive the key. So the encryption is **not** a
+defense against an attacker who exfiltrates the `~/.apitap` directory (backup,
+sync, stolen disk); the real access control there is the file permissions.
+What it does defend against is casual at-rest disclosure (the blob is not
+plaintext) and tampering (GCM authentication). For protection against an
+attacker who has the files, use full-disk encryption or an OS keychain.
+
+### PII / Secret Scrubbing
+During capture, request/response bodies, URL query parameters, and example URLs
+are scrubbed before being written to skill files. Patterns include emails,
+phone numbers (US + international), IPv4/IPv6 addresses, credit-card and SSN
+numbers, IBANs, JWTs/bearer/basic tokens, cloud-provider keys (AWS/GCP), and
+provider-prefixed secrets (Stripe, GitHub, Slack, GitLab). Body/query field
+names matching credential stems (password, secret, token, apikey, … including
+camelCase/prefixed variants) are redacted by name regardless of value.
+Credential / payment / account-security URL paths (password, 2fa, checkout,
+payment, billing, account/security) are not captured at all. Scrubbing is
+pattern-based and best-effort — it will not catch every possible secret format.
 
 ### SSRF Protection
-The replay engine validates all URLs against private IP ranges, internal hostnames, and non-HTTP schemes. DNS rebinding protection is included.
+The replay engine validates all URLs against private IP ranges, internal
+hostnames, IPv6 reserved ranges (including `::`, NAT64, site-local, IPv4-mapped),
+and non-HTTP schemes. DNS is resolved and the resolved IP re-validated before
+and after the fetch (DNS-rebinding defense), and redirects are followed manually
+one hop with per-hop re-validation and cross-domain header stripping.
 
 ### Skill File Signing
-Skill files are signed with HMAC-SHA256. Three provenance states: `self` (captured locally), `imported` (from external source), `unsigned` (no signature). Import validation includes signature verification and SSRF scanning.
+Skill files are signed with HMAC-SHA256, covering the file contents **and** the
+`provenance` field. Provenance states: `self` (all endpoints captured locally),
+`imported-signed` (contains imported endpoints; locally re-signed),
+`unsigned` (no signature, rejected on load unless `--trust-unsigned`).
+Relabelling a file does not bypass verification, and imported endpoints cannot
+inherit `self` trust. Import validation includes signature verification and
+SSRF scanning.
+
+**Signing threat model:** signatures protect against external tampering and
+file corruption, *not* same-user processes — any process running as the same
+user can derive the signing key (same machine-id + install-salt as above). This
+is the standard Unix same-user trust boundary.
 
 ### Read-Only Capture
 Playwright intercepts responses only via Chrome DevTools Protocol. No requests are modified, no code is injected into pages.

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -52,9 +52,16 @@ function connectNativePort(): void {
 
       // Otherwise, this is a CLI-initiated request relayed through the native host
       if (message.action === 'capture_request') {
+        // The relay ID must be a non-empty string we can echo back for routing;
+        // reject malformed relay messages rather than processing them.
+        if (typeof message._relayId !== 'string' || message._relayId.length === 0) {
+          console.warn('[apitap] dropping capture_request with invalid _relayId');
+          return;
+        }
+        const relayId = message._relayId;
         handleAgentCapture(message as AgentRequest).then((response) => {
           // Send response back with the relay ID so native host can route it
-          nativePort?.postMessage({ ...response, _relayId: message._relayId });
+          nativePort?.postMessage({ ...response, _relayId: relayId });
         });
       }
     });
@@ -131,7 +138,7 @@ async function saveViaBridge(skills: Array<{ domain: string; skillJson: string }
 
 // --- Agent-initiated capture ---
 
-import { isApproved, addApprovedDomain, removeApprovedDomain, getApprovedDomainEntries } from './consent.js';
+import { addApprovedDomain, removeApprovedDomain, getApprovedDomainEntries, STORAGE_KEY as APPROVED_DOMAINS_KEY } from './consent.js';
 
 // Pending consent callbacks — keyed by domain
 const pendingConsent = new Map<string, {
@@ -154,7 +161,7 @@ function requestConsentUI(domain: string): Promise<boolean> {
 
     chrome.notifications.create(notifId, {
       type: 'basic',
-      iconUrl: 'icons/48.png',
+      iconUrl: 'icons/icon48.png',
       title: 'ApiTap Agent Request',
       message: `An agent wants to capture API traffic from ${domain}. Click to allow or deny.`,
       requireInteraction: true,
@@ -339,15 +346,16 @@ async function handleAgentCapture(request: AgentRequest): Promise<AgentResponse>
     return { success: false, error: 'capture_in_progress' };
   }
 
-  // Check per-site consent
-  const approved = await isApproved(domain);
-  if (!approved) {
-    const granted = await requestConsentUI(domain);
-    if (!granted) {
-      return { success: false, error: 'user_denied' };
-    }
-    await addApprovedDomain(domain);
+  // Per-capture consent: agent/CLI-initiated captures ALWAYS prompt, even for
+  // a previously-approved domain. The 24h approval cache must not let a local
+  // process silently drive `debugger` captures of an already-approved domain
+  // (it would attach to the tab and read response bodies with no UI). The
+  // cache/approval list is retained only as a visible record in the popup.
+  const granted = await requestConsentUI(domain);
+  if (!granted) {
+    return { success: false, error: 'user_denied' };
   }
+  await addApprovedDomain(domain);
 
   // Find or open a tab for the domain
   const tab = await findOrOpenTab(domain);
@@ -636,8 +644,30 @@ let passiveIndexEnabled = PASSIVE_INDEX_DEFAULT_ENABLED;
 // --- Excluded domains (cached in memory, synced from chrome.storage.local) ---
 let excludedDomains: Set<string> = new Set();
 
+// --- Approved domains (cached in memory) — gates raw auth-token VALUE capture
+// in the passive index. Passive metadata (auth type, endpoints) is recorded for
+// all domains, but the actual token value is only captured/stored for domains
+// the user has explicitly approved, so enabling the passive index can't silently
+// harvest a brokerage/webmail bearer token (and later write it to disk via
+// auto-learn). Synced from the consent list in chrome.storage.local.
+let approvedTokenDomains: Set<string> = new Set();
+
+function approvedDomainsFromEntries(raw: unknown): Set<string> {
+  if (!Array.isArray(raw)) return new Set();
+  const now = Date.now();
+  const domains = raw
+    .filter((e): e is { domain: string; expiresAt?: string } => !!e && typeof e === 'object' && typeof (e as any).domain === 'string')
+    .filter((e) => !e.expiresAt || Date.parse(e.expiresAt) > now)
+    .map((e) => e.domain);
+  return new Set(domains);
+}
+
 chrome.storage.local.get(['excludedDomains'], (result) => {
   excludedDomains = new Set(result.excludedDomains ?? []);
+});
+
+chrome.storage.local.get([APPROVED_DOMAINS_KEY], (result) => {
+  approvedTokenDomains = approvedDomainsFromEntries(result[APPROVED_DOMAINS_KEY]);
 });
 
 chrome.storage.local.get(['passiveIndexEnabled'], (result) => {
@@ -647,6 +677,9 @@ chrome.storage.local.get(['passiveIndexEnabled'], (result) => {
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area === 'local' && changes.excludedDomains) {
     excludedDomains = new Set(changes.excludedDomains.newValue ?? []);
+  }
+  if (area === 'local' && changes[APPROVED_DOMAINS_KEY]) {
+    approvedTokenDomains = approvedDomainsFromEntries(changes[APPROVED_DOMAINS_KEY].newValue);
   }
   if (area === 'local' && changes.passiveIndexEnabled) {
     passiveIndexEnabled = resolvePassiveIndexEnabled(changes.passiveIndexEnabled.newValue);
@@ -676,9 +709,17 @@ chrome.webRequest.onSendHeaders.addListener(
       if (h.name && h.value) headers[h.name.toLowerCase()] = h.value;
     }
     const reqId = String(details.requestId);
+    // Always record auth TYPE metadata (no secret value) for the index.
     pendingObserverAuthTypes.set(reqId, detectAuthType(headers));
-    const tokens = extractAuthTokens(headers);
-    if (tokens.length > 0) pendingObserverAuthTokens.set(reqId, tokens);
+    // Only capture the raw token VALUE for domains the user explicitly approved.
+    // Otherwise enabling the passive index would silently harvest live bearer
+    // tokens from every site (and auto-learn could write them to disk).
+    let reqDomain = '';
+    try { reqDomain = new URL(details.url).hostname; } catch { /* leave empty */ }
+    if (reqDomain && approvedTokenDomains.has(reqDomain)) {
+      const tokens = extractAuthTokens(headers);
+      if (tokens.length > 0) pendingObserverAuthTokens.set(reqId, tokens);
+    }
     // Clean up if maps grow too large (prevent memory leak)
     if (pendingObserverAuthTypes.size > 1000) {
       const keys = [...pendingObserverAuthTypes.keys()];

--- a/extension/src/consent.ts
+++ b/extension/src/consent.ts
@@ -1,4 +1,4 @@
-const STORAGE_KEY = 'approvedAgentDomains';
+export const STORAGE_KEY = 'approvedAgentDomains';
 export const CONSENT_TTL_MS = 24 * 60 * 60 * 1000;
 
 export interface ApprovedDomainEntry {

--- a/extension/src/security.ts
+++ b/extension/src/security.ts
@@ -64,12 +64,29 @@ const SENSITIVE_HEADERS = new Set([
  * Scrub auth/session credentials from skill file JSON before export.
  * Replaces sensitive header values with '[stored]' placeholder.
  */
-/** Body field names that carry credentials */
-const SENSITIVE_BODY_KEYS = /^(password|passwd|pass|secret|client_secret|refresh_token|access_token|api_key|apikey|token|csrf_token|_csrf|xsrf_token|private_key|credential)$/i;
+/**
+ * Body field names that carry credentials. Normalizes the key (strip
+ * separators, lowercase) and matches credential stems so camelCase/prefixed
+ * variants (accessToken, clientSecret, userPassword) are caught too. Weak
+ * stems match only as a whole word or suffix to avoid scrubbing e.g.
+ * `tokenCount`. Keep in sync with src/skill/generator.ts isSensitiveBodyKey.
+ */
+const STRONG_BODY_KEY_STEMS = [
+  'password', 'passwd', 'secret', 'credential', 'privatekey', 'apikey',
+  'refreshtoken', 'accesstoken', 'clientsecret', 'sessiontoken', 'csrf', 'xsrf', 'bearer',
+];
+const WEAK_BODY_KEY_STEMS = ['token', 'pass', 'auth', 'pwd'];
+
+function isSensitiveBodyKey(key: string): boolean {
+  const n = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (STRONG_BODY_KEY_STEMS.some((s) => n.includes(s))) return true;
+  if (WEAK_BODY_KEY_STEMS.some((s) => n === s || n.endsWith(s))) return true;
+  return false;
+}
 
 function scrubObjectFields(obj: Record<string, unknown>): void {
   for (const key of Object.keys(obj)) {
-    if (SENSITIVE_BODY_KEYS.test(key) && typeof obj[key] === 'string') {
+    if (isSensitiveBodyKey(key) && typeof obj[key] === 'string') {
       obj[key] = '[scrubbed]';
     } else if (obj[key] && typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
       scrubObjectFields(obj[key] as Record<string, unknown>);

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "dev": "tsx src/cli.ts",
     "test": "node --import tsx --test 'test/**/*.test.ts'",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build",
-    "postpublish": "node -e \"const v=require('./package.json').version; const {execSync}=require('child_process'); execSync('gh release create v'+v+' --title v'+v+' --generate-notes', {stdio:'inherit'}); console.log('Release created: v'+v);\""
+    "prepublishOnly": "npm run build"
   },
   "license": "BSL-1.1",
   "repository": {

--- a/src/auth/handoff.ts
+++ b/src/auth/handoff.ts
@@ -24,14 +24,17 @@ export interface OAuthTokenDetection {
   scope?: string;
 }
 
-/** URL patterns for OAuth token endpoints */
-const TOKEN_URL_PATTERNS = [
-  /\/token\b/i,
+/** Specific OAuth token-endpoint patterns — an access_token here is trusted as an OAuth grant. */
+const SPECIFIC_TOKEN_URL_PATTERNS = [
   /\/oauth\/token/i,
   /\/oauth2\/token/i,
   /\/o\/oauth2\/token/i,
   /securetoken\.googleapis\.com/i,
 ];
+
+/** Broad token-endpoint pattern — matches any /token segment; requires a
+ *  corroborating OAuth field in the body before we treat it as a grant. */
+const BROAD_TOKEN_URL_PATTERN = /\/token\b/i;
 
 /**
  * Detect OAuth token endpoint response from URL, status, and body.
@@ -43,7 +46,9 @@ export function detectOAuthTokenResponse(
   body: string,
 ): OAuthTokenDetection | null {
   if (status < 200 || status >= 300) return null;
-  if (!TOKEN_URL_PATTERNS.some(p => p.test(url))) return null;
+  const specific = SPECIFIC_TOKEN_URL_PATTERNS.some(p => p.test(url));
+  const broad = BROAD_TOKEN_URL_PATTERN.test(url);
+  if (!specific && !broad) return null;
 
   let parsed: Record<string, unknown>;
   try {
@@ -53,6 +58,17 @@ export function detectOAuthTokenResponse(
   }
 
   if (typeof parsed.access_token !== 'string') return null;
+
+  // For broad /token matches (not a specific OAuth path), require a
+  // corroborating OAuth field so we don't mis-capture non-OAuth endpoints
+  // that merely return an `access_token`-named value.
+  if (!specific) {
+    const hasOAuthShape =
+      typeof parsed.token_type === 'string' ||
+      typeof parsed.expires_in === 'number' ||
+      typeof parsed.refresh_token === 'string';
+    if (!hasOAuthShape) return null;
+  }
 
   return {
     accessToken: parsed.access_token,
@@ -238,7 +254,7 @@ async function doHandoff(
       try {
         const status = response.status();
         const url = response.url();
-        if (TOKEN_URL_PATTERNS.some(p => p.test(url)) && status >= 200 && status < 300) {
+        if ((SPECIFIC_TOKEN_URL_PATTERNS.some(p => p.test(url)) || BROAD_TOKEN_URL_PATTERN.test(url)) && status >= 200 && status < 300) {
           const body = await response.text();
           const oauth = detectOAuthTokenResponse(url, status, body);
           if (oauth) {

--- a/src/auth/oauth-refresh.ts
+++ b/src/auth/oauth-refresh.ts
@@ -10,6 +10,22 @@ export interface OAuthRefreshResult {
 }
 
 /**
+ * Redact secret values from an error string before it is returned/logged.
+ * Network/runtime errors can echo request context (the refresh_token /
+ * client_secret in the POST body), so scrub any occurrence of the known
+ * secrets. Values shorter than 4 chars are ignored to avoid mangling text.
+ */
+export function redactSecrets(message: string, secrets: Array<string | undefined>): string {
+  let out = message;
+  for (const secret of secrets) {
+    if (secret && secret.length >= 4) {
+      out = out.split(secret).join('[redacted]');
+    }
+  }
+  return out;
+}
+
+/**
  * Refresh an OAuth2 access token via the token endpoint using stdlib fetch().
  * Supports refresh_token and client_credentials grant types.
  * Handles refresh token rotation (new refresh_token in response).
@@ -125,9 +141,11 @@ export async function refreshOAuth(
 
     return { success: true, tokenRotated };
   } catch (error) {
+    const raw = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : String(error),
+      // Scrub secrets that may be echoed back in network/runtime error text.
+      error: redactSecrets(raw, [oauthCreds?.refreshToken, oauthCreds?.clientSecret]),
     };
   }
 }

--- a/src/capture/filter.ts
+++ b/src/capture/filter.ts
@@ -1,5 +1,6 @@
 // src/capture/filter.ts
 import { isBlocklisted } from './blocklist.js';
+import { isSensitivePath } from './sensitive-paths.js';
 
 export interface FilterableResponse {
   url: string;
@@ -53,6 +54,8 @@ export function shouldCapture(response: FilterableResponse): boolean {
     const url = new URL(response.url);
     if (isBlocklisted(url.hostname)) return false;
     if (isPathNoise(url.pathname)) return false;
+    // Never capture credential / payment / account-security surfaces.
+    if (isSensitivePath(url.pathname)) return false;
   } catch {
     return false;
   }

--- a/src/capture/scrubber.ts
+++ b/src/capture/scrubber.ts
@@ -1,4 +1,22 @@
 // src/capture/scrubber.ts
+// NOTE: this module is bundled into the browser extension too, so it must not
+// import Node-only built-ins (e.g. node:net). IPv6 is validated with a pure helper.
+
+/**
+ * Pure (browser-safe) IPv6 validator for scrubber candidates. Rejects strings
+ * that merely look colon-separated (e.g. timestamps "12:34:56"): a full address
+ * needs 8 groups, a "::"-compressed one needs fewer with exactly one "::", and
+ * every group must be 0-4 hex digits. ReDoS-safe (split + per-group test).
+ */
+function looksLikeIpv6(s: string): boolean {
+  if (!s.includes(':')) return false;
+  const doubleColons = s.split('::').length - 1;
+  if (doubleColons > 1) return false; // at most one "::"
+  const groups = s.split(':');
+  if (groups.length > 8) return false;
+  if (!groups.every((g) => /^[0-9a-fA-F]{0,4}$/.test(g))) return false;
+  return doubleColons === 1 ? groups.length <= 8 : groups.length === 8;
+}
 
 // Email: standard pattern
 const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
@@ -28,6 +46,22 @@ const GCP_API_KEY_RE = /\bAIza[A-Za-z0-9_-]{35}\b/g;
 const PRIVATE_KEY_RE = /-----BEGIN[\s]+(?:RSA\s+|EC\s+|DSA\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END[\s]+(?:RSA\s+|EC\s+|DSA\s+)?PRIVATE\s+KEY-----/g;
 const BASIC_AUTH_RE = /\bBasic\s+[A-Za-z0-9+/]{8,}={0,2}\b/g;
 
+// Provider-prefixed secrets: Stripe (sk_/pk_/rk_ live|test), GitHub (ghp_/gho_/
+// ghu_/ghs_/ghr_), Slack (xox[baprs]-), GitLab (glpat-).
+const STRIPE_KEY_RE = /\b[sprk]k_(?:live|test)_[A-Za-z0-9]{10,}\b/g;
+const GITHUB_TOKEN_RE = /\bgh[posru]_[A-Za-z0-9]{16,}\b/g;
+const SLACK_TOKEN_RE = /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g;
+const GITLAB_TOKEN_RE = /\bglpat-[A-Za-z0-9_-]{16,}\b/g;
+
+// IBAN: 2-letter country + 2 check digits + up to 30 alphanumerics.
+const IBAN_RE = /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/g;
+
+// IPv6 candidate: 2-7 colon-separated hex groups (allowing :: compression).
+// Bounded quantifiers (no nested unbounded repetition) keep this ReDoS-safe;
+// each candidate is validated with net.isIPv6 to avoid false positives
+// (e.g. timestamps like 12:34:56).
+const IPV6_CANDIDATE_RE = /\b(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b/g;
+
 /**
  * Scrub PII from a string. Returns the string with PII replaced by placeholders.
  * Order matters: SSN before phone (SSN is more specific).
@@ -44,12 +78,18 @@ export function scrubPII(input: string): string {
   // Credit cards
   result = result.replace(CARD_RE, '[card]');
 
+  // IBAN (before IPv4 — disjoint, but keep bank identifiers grouped)
+  result = result.replace(IBAN_RE, '[iban]');
+
   // IPv4 with octet validation
   result = result.replace(IPV4_RE, (_match, o1, o2, o3, o4) => {
     const octets = [o1, o2, o3, o4].map(Number);
     if (octets.every(o => o <= 255)) return '[ip]';
     return _match;
   });
+
+  // IPv6 (validated with isIPv6 to avoid false positives)
+  result = result.replace(IPV6_CANDIDATE_RE, (m) => (looksLikeIpv6(m) ? '[ip]' : m));
 
   // Phone (international, then US)
   result = result.replace(PHONE_INTL_RE, '[phone]');
@@ -64,6 +104,12 @@ export function scrubPII(input: string): string {
   result = result.replace(AWS_ACCESS_KEY_RE, '[aws-key]');
   result = result.replace(GCP_API_KEY_RE, '[gcp-key]');
   result = result.replace(BASIC_AUTH_RE, '[token]');
+
+  // Provider-prefixed secrets
+  result = result.replace(STRIPE_KEY_RE, '[token]');
+  result = result.replace(GITHUB_TOKEN_RE, '[token]');
+  result = result.replace(SLACK_TOKEN_RE, '[token]');
+  result = result.replace(GITLAB_TOKEN_RE, '[token]');
 
   return result;
 }

--- a/src/capture/sensitive-paths.ts
+++ b/src/capture/sensitive-paths.ts
@@ -1,0 +1,35 @@
+// src/capture/sensitive-paths.ts
+// Sensitive path patterns — enforced at COLLECTION time on the capture path
+// (CLI/MCP/CDP). Requests matching these are never captured, never written;
+// data that was never written can never leak.
+//
+// SCOPE: this list deliberately covers human PII / financial / account-security
+// surfaces that should never become a replayable skill endpoint. It does NOT
+// include OAuth/token-grant/login endpoints — capturing those is the whole
+// point of ApiTap's auth subsystem (the secret is extracted into the encrypted
+// auth store and scrubbed from the skill file, only oauthConfig metadata is
+// kept). The browser extension uses a broader list (extension/src/
+// sensitive-paths.ts) because it passively indexes traffic across every site
+// the user visits, where suppressing auth endpoints is appropriate.
+const SENSITIVE_PATH_PATTERNS: RegExp[] = [
+  /\/password/i,
+  /\/passwd/i,
+  /\/reset-password/i,
+  /\/forgot-password/i,
+  /\/2fa/i,
+  /\/mfa\b/i,
+  /\/otp\b/i,
+  /\/verify-email/i,
+  /\/account\/security/i,
+  /\/checkout/i,
+  /\/payment/i,
+  /\/billing/i,
+];
+
+/**
+ * Check if a URL path matches a sensitive pattern.
+ * Returns true if the path should be BLOCKED from capture/indexing.
+ */
+export function isSensitivePath(path: string): boolean {
+  return SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(path));
+}

--- a/src/capture/verifier.ts
+++ b/src/capture/verifier.ts
@@ -1,6 +1,6 @@
 // src/capture/verifier.ts
 import type { SkillFile, SkillEndpoint, Replayability } from '../types.js';
-import { validateUrl } from '../skill/ssrf.js';
+import { resolveAndValidateUrl } from '../skill/ssrf.js';
 
 /**
  * Heuristic tier classification for non-GET endpoints (or when verification is skipped).
@@ -41,9 +41,10 @@ async function verifySingle(
   const url = endpoint.examples.request.url;
   if (!url) return classifyHeuristic(endpoint);
 
-  // SSRF check before verification fetch
+  // SSRF check before verification fetch — resolve DNS so a hostname that
+  // rebinds to a private/internal IP is caught (sync validateUrl would miss it).
   if (!skipSsrf) {
-    const ssrfResult = validateUrl(url);
+    const ssrfResult = await resolveAndValidateUrl(url);
     if (!ssrfResult.safe) return classifyHeuristic(endpoint);
   }
 
@@ -58,6 +59,9 @@ async function verifySingle(
   try {
     const response = await fetch(url, {
       headers,
+      // Do not follow redirects: a redirect Location is unvalidated and could
+      // target an internal host / cloud metadata endpoint.
+      redirect: 'manual',
       signal: AbortSignal.timeout(5000),
     });
 
@@ -102,9 +106,9 @@ async function verifySinglePost(
   const url = endpoint.examples.request.url;
   if (!url || !endpoint.requestBody) return classifyHeuristic(endpoint);
 
-  // SSRF check before verification fetch
+  // SSRF check before verification fetch — resolve DNS (see verifySingle).
   if (!skipSsrf) {
-    const ssrfResult = validateUrl(url);
+    const ssrfResult = await resolveAndValidateUrl(url);
     if (!ssrfResult.safe) return classifyHeuristic(endpoint);
   }
 
@@ -124,6 +128,9 @@ async function verifySinglePost(
       method: endpoint.method,
       headers,
       body,
+      // Do not follow redirects (see verifySingle): an unvalidated Location
+      // could target an internal host.
+      redirect: 'manual',
       signal: AbortSignal.timeout(5000),
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { writeSkillFile, readSkillFile, listSkillFiles } from './skill/store.js'
 import { replayEndpoint, getConfidenceHint } from './replay/engine.js';
 import { AuthManager, getMachineId } from './auth/manager.js';
 import { deriveSigningKey } from './auth/crypto.js';
-import { signSkillFile, signSkillFileAs } from './skill/signing.js';
+import { signSkillFile, signSkillFileAs, provenanceForSigning } from './skill/signing.js';
 import { importSkillFile } from './skill/importer.js';
 import { resolveAndValidateUrl } from './skill/ssrf.js';
 import { verifyEndpoints } from './capture/verifier.js';
@@ -807,11 +807,10 @@ async function handleOpenAPIImport(
   // Sign and write
   const machineId = await getMachineId();
   const key = deriveSigningKey(machineId);
-  // Determine provenance: 'self' if file has any captured endpoints, 'imported-signed' if all from import
-  const hasCaptured = skillFile.endpoints.some(
-    ep => !ep.endpointProvenance || ep.endpointProvenance === 'captured'
-  );
-  const signed = signSkillFileAs(skillFile, key, hasCaptured ? 'self' : 'imported-signed');
+  // Provenance is the minimum trust across endpoints: 'self' only if every
+  // endpoint is captured, else 'imported-signed' (a single imported endpoint
+  // must not let the whole file inherit 'self' trust).
+  const signed = signSkillFileAs(skillFile, key, provenanceForSigning(skillFile));
   const filePath = await writeSkillFile(signed, skillsDir);
 
   if (json) {
@@ -970,11 +969,8 @@ async function handleApisGuruImport(flags: Record<string, string | boolean>): Pr
 
       if (!dryRun) {
         // Sign and write
-        // Determine provenance: 'self' if file has any captured endpoints, 'imported-signed' if all from import
-        const hasCaptured = skillFile.endpoints.some(
-          ep => !ep.endpointProvenance || ep.endpointProvenance === 'captured'
-        );
-        const signed = signSkillFileAs(skillFile, key, hasCaptured ? 'self' : 'imported-signed');
+        // Minimum-trust provenance across endpoints (see provenanceForSigning).
+        const signed = signSkillFileAs(skillFile, key, provenanceForSigning(skillFile));
         await writeSkillFile(signed, skillsDir);
       }
 
@@ -1151,11 +1147,8 @@ async function handleSwaggerHubImport(flags: Record<string, string | boolean>): 
       skillFile.domain = domain;
       skillFile.baseUrl = `https://${domain}`;
 
-      // Sign and write
-      const hasCaptured = skillFile.endpoints.some(
-        ep => !ep.endpointProvenance || ep.endpointProvenance === 'captured'
-      );
-      const signed = signSkillFileAs(skillFile, key, hasCaptured ? 'self' : 'imported-signed');
+      // Sign and write — minimum-trust provenance (see provenanceForSigning).
+      const signed = signSkillFileAs(skillFile, key, provenanceForSigning(skillFile));
       await writeSkillFile(signed, skillsDir);
 
       if (!json) {
@@ -1443,11 +1436,8 @@ async function handleGitHubImport(flags: Record<string, string | boolean>): Prom
         continue;
       }
 
-      // Sign and write
-      const hasCaptured = skillFile.endpoints.some(
-        ep => !ep.endpointProvenance || ep.endpointProvenance === 'captured'
-      );
-      const signed = signSkillFileAs(skillFile, key, hasCaptured ? 'self' : 'imported-signed');
+      // Sign and write — minimum-trust provenance (see provenanceForSigning).
+      const signed = signSkillFileAs(skillFile, key, provenanceForSigning(skillFile));
       await writeSkillFile(signed, skillsDir);
 
       if (!json) {
@@ -1685,11 +1675,8 @@ async function handleKnownSpecsImport(flags: Record<string, string | boolean>): 
       skillFile.baseUrl = `https://${domain}`;
 
       if (!dryRun) {
-        // Sign and write
-        const hasCaptured = skillFile.endpoints.some(
-          ep => !ep.endpointProvenance || ep.endpointProvenance === 'captured'
-        );
-        const signed = signSkillFileAs(skillFile, key, hasCaptured ? 'self' : 'imported-signed');
+        // Sign and write — minimum-trust provenance (see provenanceForSigning).
+        const signed = signSkillFileAs(skillFile, key, provenanceForSigning(skillFile));
         await writeSkillFile(signed, skillsDir);
       }
 

--- a/src/known-specs-loader.ts
+++ b/src/known-specs-loader.ts
@@ -1,5 +1,6 @@
 // src/known-specs-loader.ts
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 
 export interface KnownSpec {
@@ -11,7 +12,10 @@ export interface KnownSpec {
 }
 
 export function loadKnownSpecs(): KnownSpec[] {
-  // __dirname is not defined in ESM; use import.meta.url
-  const specPath = join(new URL('.', import.meta.url).pathname, '../data/known-specs.json');
+  // __dirname is not defined in ESM; derive it from import.meta.url.
+  // fileURLToPath (not URL.pathname) handles Windows drive paths and
+  // percent-encoded characters (spaces etc.) in the install path correctly.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const specPath = join(here, '../data/known-specs.json');
   return JSON.parse(readFileSync(specPath, 'utf-8')) as KnownSpec[];
 }

--- a/src/native-host.ts
+++ b/src/native-host.ts
@@ -207,6 +207,11 @@ export function createRelayHandler(
     }
 
     if (EXTENSION_ACTIONS.has(message.action)) {
+      // Validate the domain before relaying to the browser — a direct socket
+      // client could otherwise drive the extension with an arbitrary string.
+      if (typeof message.domain !== 'string' || !isValidDomain(message.domain)) {
+        return { success: false, error: `Invalid domain: ${message.domain}` };
+      }
       try {
         return await sendToExtension(message);
       } catch (err) {
@@ -268,10 +273,17 @@ export async function startSocketServer(
     });
 
     socketServer.on('error', reject);
+    // Create the socket owner-only from the start: set a restrictive umask
+    // around listen() so there is no window where the socket is world/group
+    // accessible, then chmod (belt-and-suspenders) and only resolve once it
+    // has succeeded. The containing ~/.apitap dir is already 0o700.
+    const prevUmask = process.umask(0o077);
     socketServer.listen(socketPath, () => {
-      // Restrict socket permissions to owner only
-      fs.chmod(socketPath, 0o600).catch(() => {});
-      resolve();
+      process.umask(prevUmask);
+      fs.chmod(socketPath, 0o600).then(
+        () => resolve(),
+        () => resolve(), // chmod best-effort; umask already constrained creation
+      );
     });
   });
 }

--- a/src/replay/engine.ts
+++ b/src/replay/engine.ts
@@ -579,6 +579,14 @@ export async function replayEndpoint(
         signal: AbortSignal.timeout(30_000),
         redirect: 'manual',  // Prevent chaining
       });
+      // Post-fetch DNS re-validation on the redirect hop (symmetric with the
+      // initial request above) to narrow the TOCTOU rebinding window.
+      if (!options._skipSsrfCheck && redirectUrl.hostname && !redirectUrl.hostname.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)) {
+        const postCheck = await resolveAndValidateUrl(redirectFetchUrl);
+        if (!postCheck.safe) {
+          throw new Error(`DNS rebinding detected (post-redirect): ${postCheck.reason}`);
+        }
+      }
     }
   }
 
@@ -629,6 +637,13 @@ export async function replayEndpoint(
             signal: AbortSignal.timeout(30_000),
             redirect: 'manual',
           });
+          // Post-fetch DNS re-validation on the retry redirect hop.
+          if (!options._skipSsrfCheck && redirectUrl.hostname && !redirectUrl.hostname.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)) {
+            const postCheck = await resolveAndValidateUrl(retryRedirectFetchUrl);
+            if (!postCheck.safe) {
+              throw new Error(`DNS rebinding detected (post-redirect): ${postCheck.reason}`);
+            }
+          }
         }
       }
 

--- a/src/replay/engine.ts
+++ b/src/replay/engine.ts
@@ -174,6 +174,21 @@ function isSafeAuthRedirectHost(originalHost: string, redirectHost: string): boo
 }
 
 /**
+ * Headers safe to forward to a cross-domain redirect target. Everything else
+ * is dropped — an auth blocklist always misses some scheme (X-Session,
+ * CF-Access-Jwt-Assertion, etc.), so we allowlist non-sensitive transport
+ * headers instead and strip the rest.
+ */
+const SAFE_REDIRECT_HEADERS = new Set([
+  'accept',
+  'accept-language',
+  'accept-encoding',
+  'user-agent',
+  'content-type',
+  'content-length',
+]);
+
+/**
  * Strip auth headers from redirect request if cross-domain (H4 fix).
  * Shared between initial and retry redirect paths.
  */
@@ -182,24 +197,17 @@ function stripAuthForRedirect(
   originalHost: string,
   redirectHost: string,
 ): Record<string, string> {
-  const redirectHeaders = { ...headers };
-  if (!isSafeAuthRedirectHost(originalHost, redirectHost)) {
-    for (const key of Object.keys(redirectHeaders)) {
-      const lower = key.toLowerCase();
-      const isNamedAuthHeader =
-        lower === 'authorization' ||
-        lower === 'x-api-key' ||
-        lower === 'x-api-token' ||
-        lower === 'cookie' ||
-        lower === 'set-cookie';
-      const isAuthLikeHeader =
-        isNamedAuthHeader ||
-        lower.includes('token') ||
-        lower.includes('secret') ||
-        lower.includes('key');
-      if (isAuthLikeHeader || redirectHeaders[key] === '[stored]') {
-        delete redirectHeaders[key];
-      }
+  // Same host / single-level subdomain: forward everything (the auth belongs
+  // to that origin).
+  if (isSafeAuthRedirectHost(originalHost, redirectHost)) {
+    return { ...headers };
+  }
+  // Cross-domain: keep only the safe transport allowlist; drop any header that
+  // could carry credentials regardless of its name.
+  const redirectHeaders: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (SAFE_REDIRECT_HEADERS.has(key.toLowerCase())) {
+      redirectHeaders[key] = value;
     }
   }
   return redirectHeaders;

--- a/src/skill/generator.ts
+++ b/src/skill/generator.ts
@@ -203,8 +203,8 @@ function extractQueryParams(url: URL): Record<string, { type: string; example: s
   return params;
 }
 
-/** Query param names that carry API keys or tokens */
-const SENSITIVE_QUERY_KEYS = /api.?key|token|secret|credential|key|access.?key/i;
+/** Query param names that carry API keys, tokens, OAuth grants, or passwords */
+const SENSITIVE_QUERY_KEYS = /api.?key|token|secret|credential|key|access.?key|^code$|^state$|sig|signature|password|passwd|pwd|session.?id|^sid$|^otp$/i;
 
 function scrubQueryParams(
   params: Record<string, { type: string; example: string }>,
@@ -250,8 +250,25 @@ function scrubUrlQueryParams(urlString: string): string {
   }
 }
 
-/** Body field names that must always be scrubbed (credentials in POST bodies) */
-const SENSITIVE_BODY_KEYS = /^(password|passwd|pass|secret|client_secret|refresh_token|access_token|api_key|apikey|token|csrf_token|_csrf|xsrf_token|private_key|credential)$/i;
+/**
+ * Body field names that must always be scrubbed (credentials in POST bodies).
+ * Matches snake_case, camelCase, and prefixed variants by normalizing the key
+ * (strip separators, lowercase) and testing against credential stems. Strong
+ * stems match anywhere; weak stems (token/pass/auth/pwd) match only as a whole
+ * word or suffix so benign keys like `tokenCount` are not over-scrubbed.
+ */
+const STRONG_BODY_KEY_STEMS = [
+  'password', 'passwd', 'secret', 'credential', 'privatekey', 'apikey',
+  'refreshtoken', 'accesstoken', 'clientsecret', 'sessiontoken', 'csrf', 'xsrf', 'bearer',
+];
+const WEAK_BODY_KEY_STEMS = ['token', 'pass', 'auth', 'pwd'];
+
+export function isSensitiveBodyKey(key: string): boolean {
+  const n = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (STRONG_BODY_KEY_STEMS.some((s) => n.includes(s))) return true;
+  if (WEAK_BODY_KEY_STEMS.some((s) => n === s || n.endsWith(s))) return true;
+  return false;
+}
 
 function scrubBody(body: unknown, doScrub: boolean): unknown {
   if (!doScrub) return body;
@@ -264,7 +281,7 @@ function scrubBody(body: unknown, doScrub: boolean): unknown {
   if (body && typeof body === 'object') {
     const scrubbed: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
-      if (SENSITIVE_BODY_KEYS.test(key) && typeof value === 'string') {
+      if (isSensitiveBodyKey(key) && typeof value === 'string') {
         scrubbed[key] = '[scrubbed]';
       } else if (typeof value === 'string') {
         scrubbed[key] = scrubPII(value);

--- a/src/skill/importer.ts
+++ b/src/skill/importer.ts
@@ -95,12 +95,21 @@ export async function importSkillFile(
     return { success: false, reason: validation.reason };
   }
 
-  // Strip foreign signature, set provenance
-  const importedSkill: SkillFile = {
-    ...skill,
-    provenance: 'imported',
-    signature: undefined,
-  };
+  // Strip any foreign signature, then re-sign locally as `imported-signed`
+  // so the file is tamper-evident on subsequent loads. Leaving imported
+  // files unsigned previously let them skip verification entirely.
+  const { signSkillFileAs } = await import('./signing.js');
+  let key = localKey;
+  if (!key) {
+    const { deriveSigningKey } = await import('../auth/crypto.js');
+    const { getMachineId } = await import('../auth/manager.js');
+    key = deriveSigningKey(await getMachineId());
+  }
+  const importedSkill = signSkillFileAs(
+    { ...skill, signature: undefined, signedAt: undefined } as SkillFile,
+    key,
+    'imported-signed',
+  );
 
   const writtenPath = await writeSkillFile(importedSkill, skillsDir);
   return { success: true, skillFile: writtenPath };

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -2,6 +2,7 @@
 import { readFile, writeFile, readdir, rename } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { scrubPII } from '../capture/scrubber.js';
 
 // --- Types ---
 
@@ -123,7 +124,7 @@ export async function buildIndex(skillsDir: string = DEFAULT_SKILLS_DIR): Promis
         endpoints: skill.endpoints.map((ep: any) => ({
           id: ep.id ?? '',
           method: ep.method ?? 'GET',
-          path: ep.path ?? '/',
+          path: scrubPII(ep.path ?? '/'),
           ...(ep.replayability?.tier ? { tier: ep.replayability.tier } : {}),
           ...(ep.replayability?.verified ? { verified: true } : {}),
         })),
@@ -233,6 +234,7 @@ export async function ensureIndex(skillsDir: string = DEFAULT_SKILLS_DIR): Promi
 async function writeIndexAtomic(index: IndexFile, skillsDir: string): Promise<void> {
   const path = indexPath(skillsDir);
   const tmpPath = `${path}.${process.pid}.tmp`;
-  await writeFile(tmpPath, JSON.stringify(index));
+  // Owner-only: the index holds harvested endpoint paths, like skill files.
+  await writeFile(tmpPath, JSON.stringify(index), { mode: 0o600 });
   await rename(tmpPath, path);
 }

--- a/src/skill/signing.ts
+++ b/src/skill/signing.ts
@@ -3,11 +3,24 @@ import { hmacSign, hmacVerify } from '../auth/crypto.js';
 import type { SkillFile } from '../types.js';
 
 /**
- * Create a canonical JSON string from a skill file,
- * excluding `signature` and `provenance` fields.
+ * Create a canonical JSON string from a skill file, excluding only the
+ * `signature` field. `provenance` IS included so the trust label is
+ * authenticated — a tampered file cannot relabel itself (e.g. flip to
+ * `imported` to bypass verification) without invalidating the signature.
  * This is the payload that gets signed.
  */
 export function canonicalize(skill: SkillFile): string {
+  const { signature: _sig, ...rest } = skill;
+  return JSON.stringify(sortKeysDeep(rest));
+}
+
+/**
+ * Pre-provenance canonicalization (deep sort, provenance excluded).
+ * This was the signed format before provenance became authenticated;
+ * kept only as a verification fallback so files signed by older versions
+ * still load (and are then transparently re-signed in the new format).
+ */
+export function canonicalizePreProvenance(skill: SkillFile): string {
   const { signature: _sig, provenance: _prov, ...rest } = skill;
   return JSON.stringify(sortKeysDeep(rest));
 }
@@ -36,7 +49,8 @@ function sortKeysDeep(value: unknown): unknown {
  */
 export function signSkillFile(skill: SkillFile, key: Buffer): SkillFile {
   const signedAt = new Date().toISOString();
-  const payload = canonicalize({ ...skill, signedAt } as SkillFile);
+  // provenance must be set before canonicalizing so it is covered by the HMAC.
+  const payload = canonicalize({ ...skill, signedAt, provenance: 'self' } as SkillFile);
   const signature = hmacSign(payload, key);
   return {
     ...skill,
@@ -56,7 +70,8 @@ export function signSkillFileAs(
   provenance: 'self' | 'imported-signed',
 ): SkillFile {
   const signedAt = new Date().toISOString();
-  const payload = canonicalize({ ...skill, signedAt } as SkillFile);
+  // provenance must be set before canonicalizing so it is covered by the HMAC.
+  const payload = canonicalize({ ...skill, signedAt, provenance } as SkillFile);
   const signature = hmacSign(payload, key);
   return { ...skill, signedAt, provenance, signature };
 }
@@ -89,4 +104,29 @@ export function verifySignatureLegacyCanon(skill: SkillFile, key: Buffer): boole
   if (!skill.signature) return false;
   const payload = legacyCanonicalize(skill);
   return hmacVerify(payload, skill.signature, key);
+}
+
+/**
+ * Verify using the pre-provenance canonicalization (deep sort, provenance
+ * excluded). Returns true if the signature matches a file signed before
+ * provenance was authenticated. Callers should re-sign on a match.
+ */
+export function verifySignaturePreProvenance(skill: SkillFile, key: Buffer): boolean {
+  if (!skill.signature) return false;
+  const payload = canonicalizePreProvenance(skill);
+  return hmacVerify(payload, skill.signature, key);
+}
+
+/**
+ * Compute the provenance a skill file should be signed with, as the MINIMUM
+ * trust across its endpoints. Only `self` if every endpoint is locally
+ * captured; a single imported (openapi-import) or skeleton endpoint
+ * downgrades the whole file to `imported-signed` so untrusted endpoints can
+ * never inherit `self` trust by being merged into a captured file.
+ */
+export function provenanceForSigning(skill: SkillFile): 'self' | 'imported-signed' {
+  const allCaptured = skill.endpoints.every(
+    (ep) => !ep.endpointProvenance || ep.endpointProvenance === 'captured',
+  );
+  return allCaptured ? 'self' : 'imported-signed';
 }

--- a/src/skill/ssrf.ts
+++ b/src/skill/ssrf.ts
@@ -44,6 +44,18 @@ export function validateUrl(urlString: string): ValidationResult {
     }
   }
 
+  // IPv6 literal hosts: delegate to the comprehensive isPrivateIp check,
+  // which covers ::, ::1, multicast, documentation, NAT64, IPv4-mapped, and
+  // link/site/unique-local. This closes literals (e.g. [::]) that the
+  // pattern checks below miss, and unifies literal handling in one place.
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    const inner = hostname.slice(1, -1);
+    const reason = isPrivateIp(inner);
+    if (reason) {
+      return { safe: false, reason: `URL targets reserved IPv6 address: ${inner} (${reason})` };
+    }
+  }
+
   // IPv6 loopback
   if (hostname === '[::1]' || hostname === '::1') {
     return { safe: false, reason: 'URL targets IPv6 loopback' };
@@ -209,6 +221,12 @@ function isPrivateIp(ip: string): string | null {
     if (/^ff[0-9a-f]{2}:/i.test(ipv4)) return 'IPv6 multicast';
     if (/^2001:db8:/i.test(ipv4)) return 'IPv6 documentation (2001:db8::/32)';
     if (/^100::/i.test(ipv4)) return 'IPv6 discard prefix (100::/64)';
+    // NAT64 translation prefix — embeds an IPv4 address in the low 32 bits,
+    // so it can reach internal IPv4 hosts (e.g. 64:ff9b::7f00:1 → 127.0.0.1).
+    if (/^64:ff9b:/i.test(ipv4)) return 'IPv6 NAT64 (64:ff9b::/96)';
+    // Deprecated site-local fec0::/10 (fec0–feff); link-local fe80::/10 is
+    // handled above by the fe[89ab] check.
+    if (/^fe[c-f][0-9a-f]:/i.test(ipv4)) return 'IPv6 site-local (deprecated fec0::/10)';
     // Validate textual format with Node's own IPv6 parser. Rejects
     // malformed input (too many colons, out-of-range groups, etc.).
     if (!isIPv6(ipv4)) return 'unrecognized IP format';
@@ -255,8 +273,20 @@ export async function resolveAndValidateUrl(urlString: string): Promise<Validati
 
   const hostname = url.hostname;
 
-  // Skip DNS resolution for raw IPs (already checked by validateUrl)
-  if (hostname.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/) || hostname.startsWith('[')) {
+  // Skip DNS resolution for raw IPv4 literals (already range-checked by validateUrl).
+  if (hostname.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)) {
+    return { safe: true };
+  }
+
+  // IPv6 literals have no DNS to resolve, but must still be range-checked
+  // here rather than short-circuited to safe — validateUrl already ran, but
+  // re-assert via isPrivateIp so a reserved literal can never slip through.
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    const inner = hostname.slice(1, -1);
+    const reason = isPrivateIp(inner);
+    if (reason) {
+      return { safe: false, reason: `URL targets reserved IPv6 address: ${inner} (${reason})` };
+    }
     return { safe: true };
   }
 

--- a/src/skill/store.ts
+++ b/src/skill/store.ts
@@ -147,10 +147,14 @@ export async function readSkillFile(
             if (verified) needsResign = true;
           }
 
-          if (!verified) {
-            // Fallback 4: pre-Feb-22-2026 fixed salt key + legacy canonicalization
-            // Files captured before 7fc489b used pbkdf2(machineId, 'apitap-v0.2-key-derivation')
-            // regardless of per-install salt (which didn't exist yet)
+          if (!verified && process.env.APITAP_ALLOW_LEGACY_KEYS === '1') {
+            // Fallback 4 (opt-in): pre-Feb-22-2026 fixed salt key + legacy
+            // canonicalization. Files captured before 7fc489b used
+            // pbkdf2(machineId, 'apitap-v0.2-key-derivation') regardless of
+            // per-install salt. This salt is a public constant, so on cloned
+            // machine-id fleets (containers/VM templates) the key is shared
+            // and forgeable — gate it behind APITAP_ALLOW_LEGACY_KEYS=1 so it
+            // is only used for an explicit one-off migration of old files.
             const { pbkdf2Sync } = await import('node:crypto');
             const fixedSaltKey = pbkdf2Sync(machineId, 'apitap-v0.2-key-derivation', 100_000, 32, 'sha512');
             verified = verifySignatureLegacyCanon(skill, fixedSaltKey);

--- a/src/skill/store.ts
+++ b/src/skill/store.ts
@@ -102,10 +102,12 @@ export async function readSkillFile(
         signingKey = deriveSigningKey(machineId);
       }
 
-      if (skill.provenance === 'imported') {
-        // Imported files had foreign signature stripped — can't verify
-      } else if (!skill.signature) {
-        // Unsigned files are rejected unless trustUnsigned is set
+      if (!skill.signature) {
+        // Unsigned files are rejected unless trustUnsigned is set. This now
+        // includes legacy `imported` files (which were stored without a
+        // signature); they must be re-imported (and locally signed) or
+        // loaded with --trust-unsigned. Relabelling a file `imported` no
+        // longer bypasses verification.
         if (!options?.trustUnsigned) {
           throw new Error(
             `Skill file for ${domain} is unsigned and cannot be verified. ` +
@@ -113,9 +115,15 @@ export async function readSkillFile(
           );
         }
       } else {
-        const { verifySignature, verifySignatureLegacyCanon } = await import('./signing.js');
+        const { verifySignature, verifySignatureLegacyCanon, verifySignaturePreProvenance } = await import('./signing.js');
         let verified = verifySignature(skill, signingKey);
         let needsResign = false;
+        if (!verified) {
+          // Fallback 0: pre-provenance canonicalization with the current key.
+          // Files signed before provenance was authenticated match here.
+          verified = verifySignaturePreProvenance(skill, signingKey);
+          if (verified) needsResign = true;
+        }
         if (!verified) {
           // Fallback 1: try pre-v1.4.0 legacy key (before HKDF signing key separation)
           // Files signed with deriveKey() directly (not deriveSigningKey()) will match here
@@ -156,11 +164,11 @@ export async function readSkillFile(
         // Transparent migration: re-sign with current format so future loads are fast
         if (needsResign) {
           try {
-            const { signSkillFileAs } = await import('./signing.js');
+            const { signSkillFileAs, provenanceForSigning } = await import('./signing.js');
             const resigned = signSkillFileAs(
               { ...skill, signature: undefined, signedAt: undefined } as unknown as SkillFile,
               signingKey,
-              skill.provenance as 'self' | 'imported-signed',
+              provenanceForSigning(skill),
             );
             await writeSkillFile(resigned, skillsDir);
           } catch {

--- a/src/skill/store.ts
+++ b/src/skill/store.ts
@@ -4,6 +4,7 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import type { SkillFile, SkillSummary } from '../types.js';
 import { validateSkillFile } from './validate.js';
+import { scrubPII } from '../capture/scrubber.js';
 import { updateIndex, ensureIndex } from './index.js';
 
 const DEFAULT_SKILLS_DIR = join(homedir(), '.apitap', 'skills');
@@ -58,7 +59,7 @@ export async function writeSkillFile(
       skill.endpoints.map(ep => ({
         id: ep.id,
         method: ep.method,
-        path: ep.path,
+        path: scrubPII(ep.path),
         ...(ep.replayability?.tier ? { tier: ep.replayability.tier } : {}),
         ...(ep.replayability?.verified ? { verified: true } : {}),
       })),

--- a/test/auth/handoff.test.ts
+++ b/test/auth/handoff.test.ts
@@ -126,4 +126,26 @@ describe('detectOAuthTokenResponse', () => {
     );
     assert.equal(result, null);
   });
+
+  it('does not mis-capture a generic /token endpoint that returns access_token without OAuth shape', () => {
+    // /api/token matches the broad /token pattern but, lacking token_type /
+    // expires_in / refresh_token, may be a non-OAuth ticket/handle — don't
+    // treat its value as a stored OAuth credential.
+    const result = detectOAuthTokenResponse(
+      'https://example.com/api/token',
+      200,
+      JSON.stringify({ access_token: 'one-time-download-handle' }),
+    );
+    assert.equal(result, null);
+  });
+
+  it('still captures a broad /token match when the body is OAuth-shaped', () => {
+    const result = detectOAuthTokenResponse(
+      'https://example.com/v2/token',
+      200,
+      JSON.stringify({ access_token: 'tok', expires_in: 3600 }),
+    );
+    assert.ok(result);
+    assert.equal(result!.accessToken, 'tok');
+  });
 });

--- a/test/auth/oauth-refresh.test.ts
+++ b/test/auth/oauth-refresh.test.ts
@@ -5,8 +5,22 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AuthManager } from '../../src/auth/manager.js';
-import { refreshOAuth } from '../../src/auth/oauth-refresh.js';
+import { refreshOAuth, redactSecrets } from '../../src/auth/oauth-refresh.js';
 import type { OAuthConfig } from '../../src/types.js';
+
+describe('redactSecrets', () => {
+  it('redacts secret values from an error message', () => {
+    const msg = 'connect failed for body grant_type=refresh_token&refresh_token=RT_SECRET&client_secret=CS_SECRET';
+    const out = redactSecrets(msg, ['RT_SECRET', 'CS_SECRET']);
+    assert.ok(!out.includes('RT_SECRET'), 'refresh token must be redacted');
+    assert.ok(!out.includes('CS_SECRET'), 'client secret must be redacted');
+    assert.ok(out.includes('[redacted]'));
+  });
+
+  it('ignores empty/undefined secrets and short values', () => {
+    assert.equal(redactSecrets('plain error', [undefined, '', 'ab']), 'plain error');
+  });
+});
 
 describe('refreshOAuth', () => {
   let testDir: string;

--- a/test/capture/filter.test.ts
+++ b/test/capture/filter.test.ts
@@ -12,6 +12,43 @@ describe('shouldCapture', () => {
     }), true);
   });
 
+  describe('drops sensitive PII / financial / account-security paths', () => {
+    const sensitive = [
+      'https://api.example.com/account/security',
+      'https://api.example.com/checkout',
+      'https://api.example.com/payment/methods',
+      'https://api.example.com/billing/invoices',
+      'https://api.example.com/users/me/password',
+      'https://api.example.com/reset-password',
+      'https://api.example.com/2fa/verify',
+    ];
+    for (const url of sensitive) {
+      it(`drops ${url} even when 2xx JSON`, () => {
+        assert.equal(
+          shouldCapture({ url, status: 200, contentType: 'application/json' }),
+          false,
+          `${url} is a sensitive path and must not be captured`,
+        );
+      });
+    }
+
+    it('still captures OAuth/token endpoints (auth capture is intentional)', () => {
+      // ApiTap's auth subsystem is designed to capture these; the secret is
+      // extracted to the encrypted store and scrubbed from the skill file.
+      for (const url of [
+        'https://api.example.com/oauth/token',
+        'https://api.example.com/login',
+        'https://api.example.com/authors', // also: must not match a credential pattern
+      ]) {
+        assert.equal(
+          shouldCapture({ url, status: 200, contentType: 'application/json' }),
+          true,
+          `${url} should remain capturable`,
+        );
+      }
+    });
+  });
+
   it('keeps JSON responses with charset parameter', () => {
     assert.equal(shouldCapture({
       url: 'https://api.example.com/data',

--- a/test/capture/scrubber.test.ts
+++ b/test/capture/scrubber.test.ts
@@ -26,6 +26,34 @@ describe('scrubPII', () => {
     assert.equal(scrubPII('product SKU-99887766'), 'product SKU-99887766');
   });
 
+  it('redacts provider-prefixed API keys and tokens', () => {
+    // Tokens are assembled at runtime (prefix + body) so these synthetic
+    // fixtures don't trip GitHub push-protection secret scanning while still
+    // exercising the scrubber patterns.
+    const stripeSk = 'sk_' + 'live_' + '4eC39HqLyjWDarjtT1zdp7dc';
+    const stripePk = 'pk_' + 'live_' + 'abcDEF123456ghiJKL789012';
+    const ghp = 'ghp_' + '16C7e42F292c6912E7710c838347Ae178B4a';
+    const gho = 'gho_' + '16C7e42F292c6912E7710c838347Ae178B4a';
+    const slack = 'xoxb-' + '2345678901-2345678901234-AbCdEfGhIjKlMnOpQr';
+    const gitlab = 'glpat-' + 'AbCdEf12345678901234';
+    assert.equal(scrubPII('key ' + stripeSk), 'key [token]');
+    assert.equal(scrubPII('pub ' + stripePk), 'pub [token]');
+    assert.equal(scrubPII('gh ' + ghp), 'gh [token]');
+    assert.equal(scrubPII('gh ' + gho), 'gh [token]');
+    assert.equal(scrubPII('slack ' + slack), 'slack [token]');
+    assert.equal(scrubPII('gl ' + gitlab), 'gl [token]');
+  });
+
+  it('redacts IBANs', () => {
+    assert.equal(scrubPII('iban DE89370400440532013000 ok'), 'iban [iban] ok');
+    assert.equal(scrubPII('GB29NWBK60161331926819'), '[iban]');
+  });
+
+  it('redacts IPv6 addresses', () => {
+    assert.equal(scrubPII('host 2001:db8::1 here'), 'host [ip] here');
+    assert.equal(scrubPII('fe80::1ff:fe23:4567:890a'), '[ip]');
+  });
+
   it('redacts IPv4 addresses with valid octets', () => {
     assert.equal(scrubPII('server at 192.168.1.1'), 'server at [ip]');
     assert.equal(scrubPII('from 10.0.0.1 to 172.16.0.1'), 'from [ip] to [ip]');

--- a/test/capture/verifier.test.ts
+++ b/test/capture/verifier.test.ts
@@ -77,6 +77,9 @@ describe('verifyEndpoints', () => {
       } else if (req.url === '/api/post-fail' && req.method === 'POST') {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'bad request' }));
+      } else if (req.url === '/api/redirect') {
+        res.writeHead(302, { Location: '/api/public' });
+        res.end();
       } else {
         res.writeHead(404);
         res.end();
@@ -283,6 +286,36 @@ describe('verifyEndpoints', () => {
 
     const verified = await verifyEndpoints(skill, { _skipSsrfCheck: true });
     assert.equal(verified.endpoints[0].replayability?.verified, false);
+  });
+
+  it('does not follow redirects during verification (SSRF: redirect could target internal hosts)', async () => {
+    const skill: SkillFile = {
+      version: '1.2',
+      domain: 'localhost',
+      capturedAt: new Date().toISOString(),
+      baseUrl,
+      endpoints: [
+        makeEndpoint({
+          id: 'get-api-redirect',
+          path: '/api/redirect',
+          examples: {
+            request: { url: `${baseUrl}/api/redirect`, headers: {} },
+            responsePreview: null,
+          },
+        }),
+      ],
+      metadata: { captureCount: 1, filteredCount: 0, toolVersion: '0.3.0' },
+      provenance: 'unsigned',
+    };
+
+    const verified = await verifyEndpoints(skill, { _skipSsrfCheck: true });
+    const r = verified.endpoints[0].replayability;
+    // The 302 must be reported as-is, not silently followed to the /api/public 200.
+    assert.notEqual(r?.tier, 'green', 'a redirect must not be followed and reported as a green verified endpoint');
+    assert.ok(
+      r?.signals.some(s => s.startsWith('status-3')),
+      `expected a 3xx status signal, got ${JSON.stringify(r?.signals)}`,
+    );
   });
 
   it('returns skill unchanged when no endpoints', async () => {

--- a/test/native-host.test.ts
+++ b/test/native-host.test.ts
@@ -164,6 +164,12 @@ describe('unix socket relay', () => {
     assert.equal(response.action, 'pong');
   });
 
+  it('creates the socket owner-only (0o600) by the time it accepts', async () => {
+    await startSocketServer(socketPath, async () => ({ success: true }));
+    const st = await fs.stat(socketPath);
+    assert.equal(st.mode & 0o777, 0o600, 'socket must be 0o600 with no world/group access window');
+  });
+
   it('handles concurrent CLI connections', async () => {
     const mockHandler = async (msg: any) => {
       await new Promise(r => setTimeout(r, 50));
@@ -244,6 +250,18 @@ describe('relay handler', () => {
 
     assert.equal(result.success, true);
     assert.deepEqual(relayedMessage, { action: 'capture_request', domain: 'x.com' });
+  });
+
+  it('rejects capture_request with an invalid domain before relaying', async () => {
+    let relayed = false;
+    const sendToExtension = async (msg: any) => { relayed = true; return { success: true }; };
+    const handler = createRelayHandler(sendToExtension);
+
+    for (const domain of ['../etc', 'evil.com/../x', 'has space', '']) {
+      const result = await handler({ action: 'capture_request', domain });
+      assert.equal(result.success, false, `domain ${JSON.stringify(domain)} should be rejected`);
+    }
+    assert.equal(relayed, false, 'invalid domains must not reach the extension');
   });
 
   it('returns error when extension relay fails', async () => {

--- a/test/replay/engine.test.ts
+++ b/test/replay/engine.test.ts
@@ -1172,6 +1172,9 @@ describe('replayEndpoint redirect auth stripping', () => {
         'x-custom-token': req.headers['x-custom-token'] as string | undefined,
         'x-custom-secret': req.headers['x-custom-secret'] as string | undefined,
         'x-custom-key': req.headers['x-custom-key'] as string | undefined,
+        'x-session': req.headers['x-session'] as string | undefined,
+        'cf-access-jwt-assertion': req.headers['cf-access-jwt-assertion'] as string | undefined,
+        accept: req.headers['accept'] as string | undefined,
       };
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ ok: true }));
@@ -1254,6 +1257,49 @@ describe('replayEndpoint redirect auth stripping', () => {
       assert.equal(receivedHeaders['x-custom-token'], undefined);
       assert.equal(receivedHeaders['x-custom-secret'], undefined);
       assert.equal(receivedHeaders['x-custom-key'], undefined);
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('strips custom auth headers that lack token/secret/key in the name (allowlist)', async () => {
+    const skill: SkillFile = {
+      version: '1.2',
+      domain: 'localhost',
+      capturedAt: new Date().toISOString(),
+      baseUrl: originBaseUrl,
+      endpoints: [{
+        id: 'get-start',
+        method: 'GET',
+        path: '/start',
+        queryParams: {},
+        headers: {},
+        responseShape: { type: 'object' },
+        examples: { request: { url: `${originBaseUrl}/start`, headers: {} }, responsePreview: null },
+      }],
+      metadata: { captureCount: 1, filteredCount: 0, toolVersion: '1.0.0' },
+      provenance: 'self',
+    };
+
+    const testDir = await mkdtemp(join(tmpdir(), 'apitap-redirect-allow-'));
+    try {
+      const authManager = new AuthManager(testDir, 'test-machine-id');
+      await authManager.store('localhost', {
+        type: 'custom',
+        header: 'x-session',
+        value: 'SECRET_SESSION',
+        headers: [
+          { header: 'x-session', value: 'SECRET_SESSION' },
+          { header: 'cf-access-jwt-assertion', value: 'SECRET_CF_JWT' },
+        ],
+      });
+
+      await replayEndpoint(skill, 'get-start', { authManager, domain: 'localhost', _skipSsrfCheck: true });
+
+      // Neither header contains token/secret/key, but both carry credentials
+      // and must not leak to the cross-domain redirect target.
+      assert.equal(receivedHeaders['x-session'], undefined, 'x-session must be stripped');
+      assert.equal(receivedHeaders['cf-access-jwt-assertion'], undefined, 'cf-access-jwt-assertion must be stripped');
     } finally {
       await rm(testDir, { recursive: true, force: true });
     }

--- a/test/security/audit-fixes.test.ts
+++ b/test/security/audit-fixes.test.ts
@@ -138,11 +138,13 @@ describe('H1: Signature verification enforcement', () => {
     assert.ok(loaded);
   });
 
-  it('skips verification for imported files', async () => {
+  it('does not skip verification for unsigned files labeled "imported"', async () => {
+    // Security fix: `imported` provenance no longer bypasses verification.
     await writeSkillFile(makeSkill({ provenance: 'imported' as const }), testDir);
-    const loaded = await readSkillFile('example.com', testDir, { signingKey });
-    assert.ok(loaded);
-    assert.equal(loaded.provenance, 'imported');
+    await assert.rejects(
+      () => readSkillFile('example.com', testDir, { signingKey }),
+      /unsigned/i,
+    );
   });
 });
 

--- a/test/security/ipv6-literal-ssrf.test.ts
+++ b/test/security/ipv6-literal-ssrf.test.ts
@@ -1,0 +1,52 @@
+// test/security/ipv6-literal-ssrf.test.ts
+// IPv6 literal hosts must be validated against reserved ranges by BOTH the
+// sync check and the DNS-resolving check (which previously short-circuited
+// any bracketed host to "safe").
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateUrl, resolveAndValidateUrl } from '../../src/skill/ssrf.js';
+
+const BLOCKED = [
+  ['http://[::]/', 'unspecified (::)'],
+  ['http://[::1]/', 'loopback (::1)'],
+  ['http://[::ffff:127.0.0.1]/', 'IPv4-mapped loopback'],
+  ['http://[fe80::1]/', 'link-local'],
+  ['http://[fd00::1]/', 'unique-local'],
+  ['http://[64:ff9b::7f00:1]/', 'NAT64 embedding 127.0.0.1'],
+  ['http://[fec0::1]/', 'deprecated site-local'],
+] as const;
+
+const ALLOWED = [
+  'http://[2606:4700:4700::1111]/', // Cloudflare public DNS
+  'http://[2001:4860:4860::8888]/', // Google public DNS
+] as const;
+
+describe('IPv6 literal SSRF — sync validateUrl', () => {
+  for (const [url, label] of BLOCKED) {
+    it(`blocks ${label}: ${url}`, () => {
+      assert.equal(validateUrl(url).safe, false, `${url} must be blocked`);
+    });
+  }
+
+  for (const url of ALLOWED) {
+    it(`allows public IPv6 literal ${url}`, () => {
+      assert.equal(validateUrl(url).safe, true, `${url} must be allowed`);
+    });
+  }
+});
+
+describe('IPv6 literal SSRF — resolveAndValidateUrl (no short-circuit)', () => {
+  for (const [url, label] of BLOCKED) {
+    it(`blocks ${label}: ${url}`, async () => {
+      const result = await resolveAndValidateUrl(url);
+      assert.equal(result.safe, false, `${url} must be blocked by the resolving check too`);
+    });
+  }
+
+  for (const url of ALLOWED) {
+    it(`allows public IPv6 literal ${url}`, async () => {
+      const result = await resolveAndValidateUrl(url);
+      assert.equal(result.safe, true, `${url} must be allowed`);
+    });
+  }
+});

--- a/test/security/provenance-integrity.test.ts
+++ b/test/security/provenance-integrity.test.ts
@@ -1,0 +1,128 @@
+// test/security/provenance-integrity.test.ts
+// Integrity: provenance must be authenticated by the signature, and the
+// `imported` provenance value must not bypass signature verification.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  signSkillFile,
+  signSkillFileAs,
+  verifySignature,
+  provenanceForSigning,
+} from '../../src/skill/signing.js';
+import { deriveKey } from '../../src/auth/crypto.js';
+import { readSkillFile } from '../../src/skill/store.js';
+import { importSkillFile } from '../../src/skill/importer.js';
+import type { SkillFile, SkillEndpoint } from '../../src/types.js';
+
+const key = deriveKey('test-machine-id');
+
+function endpoint(id: string, prov?: SkillEndpoint['endpointProvenance']): SkillEndpoint {
+  return {
+    id,
+    method: 'GET',
+    path: `/api/${id}`,
+    queryParams: {},
+    headers: {},
+    responseShape: { type: 'array', fields: ['id'] },
+    examples: {
+      request: { url: `https://example.com/api/${id}`, headers: {} },
+      responsePreview: null,
+    },
+    ...(prov ? { endpointProvenance: prov } : {}),
+  };
+}
+
+function makeSkill(endpoints = [endpoint('data')]): SkillFile {
+  return {
+    version: '1.1',
+    domain: 'example.com',
+    capturedAt: '2026-02-04T12:00:00.000Z',
+    baseUrl: 'https://example.com',
+    endpoints,
+    metadata: { captureCount: 1, filteredCount: 0, toolVersion: '0.2.0' },
+    provenance: 'unsigned',
+  };
+}
+
+describe('provenance is authenticated by the signature', () => {
+  it('verifySignature fails when provenance is tampered after signing', () => {
+    const signed = signSkillFile(makeSkill(), key); // provenance: 'self'
+    assert.equal(verifySignature(signed, key), true);
+
+    const tampered = { ...signed, provenance: 'imported' as const };
+    assert.equal(
+      verifySignature(tampered, key),
+      false,
+      'flipping provenance to "imported" must invalidate the signature',
+    );
+  });
+});
+
+describe('imported provenance does not bypass verification', () => {
+  it('a tampered file claiming provenance:"imported" is rejected on load', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'apitap-prov-'));
+    try {
+      // Start from a legitimately self-signed file, then inject an endpoint
+      // and relabel it as imported (the classic verification-skip bypass).
+      // baseUrl stays on-domain so validateSkillFile's domain-lock isn't what
+      // rejects it — the signature check must.
+      const signed = signSkillFile(makeSkill(), key);
+      const tampered: SkillFile = {
+        ...signed,
+        endpoints: [...signed.endpoints, endpoint('injected')],
+        provenance: 'imported',
+      };
+      await writeFile(join(dir, 'example.com.json'), JSON.stringify(tampered), 'utf-8');
+
+      await assert.rejects(
+        () => readSkillFile('example.com', dir, { signingKey: key }),
+        /verification failed|tamper/i,
+        'imported provenance must not skip signature verification',
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('importSkillFile signs imported files locally', () => {
+  it('writes an imported-signed file that verifies and loads', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'apitap-imp-'));
+    try {
+      // A foreign skill file with no signature, arriving from outside.
+      const foreign = makeSkill();
+      const srcPath = join(dir, 'foreign.json');
+      await writeFile(srcPath, JSON.stringify(foreign), 'utf-8');
+
+      const result = await importSkillFile(srcPath, dir, key);
+      assert.equal(result.success, true, result.success ? '' : result.reason);
+
+      // The stored file must carry a local signature, not be left unsigned.
+      const stored = await readSkillFile('example.com', dir, { signingKey: key });
+      assert.ok(stored, 'imported file should load');
+      assert.equal(stored!.provenance, 'imported-signed');
+      assert.equal(verifySignature(stored!, key), true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('provenanceForSigning enforces minimum trust', () => {
+  it('returns self only when every endpoint is captured', () => {
+    const captured = makeSkill([endpoint('a'), endpoint('b', 'captured')]);
+    assert.equal(provenanceForSigning(captured), 'self');
+  });
+
+  it('returns imported-signed when any endpoint comes from an import', () => {
+    const mixed = makeSkill([endpoint('a', 'captured'), endpoint('b', 'openapi-import')]);
+    assert.equal(
+      provenanceForSigning(mixed),
+      'imported-signed',
+      'a single imported endpoint must downgrade the whole file from self',
+    );
+  });
+});

--- a/test/skill/generator.test.ts
+++ b/test/skill/generator.test.ts
@@ -1,8 +1,28 @@
 // test/skill/generator.test.ts
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { SkillGenerator } from '../../src/skill/generator.js';
+import { SkillGenerator, isSensitiveBodyKey } from '../../src/skill/generator.js';
 import type { CapturedExchange } from '../../src/types.js';
+
+describe('isSensitiveBodyKey', () => {
+  it('matches snake_case and bare credential keys', () => {
+    for (const k of ['password', 'client_secret', 'refresh_token', 'access_token', 'api_key', 'token', 'private_key']) {
+      assert.equal(isSensitiveBodyKey(k), true, `${k} should be sensitive`);
+    }
+  });
+
+  it('matches camelCase and prefixed variants (previously missed)', () => {
+    for (const k of ['accessToken', 'refreshToken', 'clientSecret', 'userPassword', 'apiKey', 'authToken', 'privateKey']) {
+      assert.equal(isSensitiveBodyKey(k), true, `${k} should be sensitive`);
+    }
+  });
+
+  it('does not match benign keys', () => {
+    for (const k of ['username', 'tokenCount', 'id', 'email', 'title', 'description']) {
+      assert.equal(isSensitiveBodyKey(k), false, `${k} should not be sensitive`);
+    }
+  });
+});
 
 function mockExchange(overrides: {
   url?: string;
@@ -220,6 +240,19 @@ describe('SkillGenerator', () => {
     const params = skill.endpoints[0].queryParams;
     assert.equal(params['email'].example, '[email]');
     assert.equal(params['limit'].example, '10');
+  });
+
+  it('scrubs OAuth code/state and password query params (even when short)', () => {
+    const gen = new SkillGenerator();
+    gen.addExchange(mockExchange({
+      url: 'https://example.com/api/callback?code=abc123&state=xyz&password=hunter2&keep=ok',
+    }));
+
+    const params = gen.toSkillFile('example.com').endpoints[0].queryParams;
+    assert.equal(params['code'].example, '[scrubbed]');
+    assert.equal(params['state'].example, '[scrubbed]');
+    assert.equal(params['password'].example, '[scrubbed]');
+    assert.equal(params['keep'].example, 'ok');
   });
 
   it('scrubs PII from example request URL', () => {

--- a/test/skill/importer.test.ts
+++ b/test/skill/importer.test.ts
@@ -91,7 +91,7 @@ describe('skill file import', () => {
   });
 
   describe('importSkillFile', () => {
-    it('copies skill file with provenance set to imported', async () => {
+    it('signs imported file locally as imported-signed', async () => {
       const filePath = join(testDir, 'import.json');
       await writeFile(filePath, JSON.stringify(makeSkill()));
 
@@ -100,8 +100,9 @@ describe('skill file import', () => {
 
       const { readSkillFile } = await import('../../src/skill/store.js');
       const loaded = await readSkillFile('api.example.com', skillsDir);
-      assert.equal(loaded!.provenance, 'imported');
-      assert.equal(loaded!.signature, undefined);
+      assert.equal(loaded!.provenance, 'imported-signed');
+      // Imported files are now locally signed (tamper-evident), not left unsigned.
+      assert.ok(loaded!.signature?.startsWith('hmac-sha256:'));
     });
 
     it('rejects file with SSRF URLs', async () => {

--- a/test/skill/index.test.ts
+++ b/test/skill/index.test.ts
@@ -47,6 +47,28 @@ describe('search index', () => {
     await rm(join(skillsDir, '..'), { recursive: true, force: true });
   });
 
+  describe('privacy of index.json', () => {
+    it('scrubs PII from endpoint paths and writes the index 0o600', async () => {
+      const { stat } = await import('node:fs/promises');
+      await writeFile(
+        join(skillsDir, 'api.example.com.json'),
+        makeSkillJSON('api.example.com', [
+          { id: 'get-user', method: 'GET', path: '/users/jane@example.com/profile' },
+        ]),
+      );
+      await buildIndex(skillsDir);
+
+      const index = await readIndex(skillsDir);
+      const path = index!.domains['api.example.com'].endpoints[0].path;
+      assert.ok(!path.includes('jane@example.com'), `path must be scrubbed, got ${path}`);
+      assert.ok(path.includes('[email]'), `expected [email] placeholder, got ${path}`);
+
+      // index.json holds harvested paths — must be owner-only like skill files.
+      const st = await stat(join(skillsDir, '..', 'index.json'));
+      assert.equal(st.mode & 0o777, 0o600, 'index.json must be mode 0o600');
+    });
+  });
+
   describe('buildIndex', () => {
     it('builds index from skill files on disk', async () => {
       await writeFile(

--- a/test/skill/signing-enforcement.test.ts
+++ b/test/skill/signing-enforcement.test.ts
@@ -79,11 +79,15 @@ describe('HMAC enforcement Phase 2', () => {
     assert.ok(loaded, 'Unsigned file should load with trustUnsigned');
   });
 
-  it('imported file skips verification', async () => {
+  it('unsigned file labeled "imported" no longer bypasses verification', async () => {
+    // Security fix: relabelling a file `imported` used to skip verification.
+    // An imported file with no signature is now treated as unsigned.
     const skill = makeSkill({ provenance: 'imported' });
     await writeSkillFile(skill, testDir);
-    const loaded = await readSkillFile('example.com', testDir, { verifySignature: true, signingKey });
-    assert.ok(loaded, 'Imported file should skip verification');
+    await assert.rejects(
+      () => readSkillFile('example.com', testDir, { verifySignature: true, signingKey }),
+      /unsigned/i,
+    );
   });
 
   it('file signed with wrong key is rejected', async () => {

--- a/test/skill/signing.test.ts
+++ b/test/skill/signing.test.ts
@@ -62,10 +62,15 @@ describe('skill file signing', () => {
     assert.equal(verifySignature(skill, key), false);
   });
 
-  it('canonicalize excludes signature and provenance', () => {
-    const a = makeSkill();
+  it('canonicalize excludes signature but includes provenance', () => {
+    // signature is excluded from the payload...
+    const a = { ...makeSkill(), provenance: 'self' as const };
     const b = { ...makeSkill(), signature: 'hmac-sha256:abc', provenance: 'self' as const };
     assert.equal(canonicalize(a), canonicalize(b));
+    // ...but provenance is now authenticated, so it changes the payload.
+    const self = { ...makeSkill(), provenance: 'self' as const };
+    const imported = { ...makeSkill(), provenance: 'imported' as const };
+    assert.notEqual(canonicalize(self), canonicalize(imported));
   });
 
   it('legacyCanonicalize uses shallow key sort (differs from deep sort for nested objects)', () => {

--- a/test/skill/store-verify.test.ts
+++ b/test/skill/store-verify.test.ts
@@ -89,17 +89,24 @@ describe('F4: Signature verification on load', () => {
     assert.equal(loaded.baseUrl, 'https://example.com');
   });
 
-  it('unsigned/imported skill file passes without verification error', async () => {
-    // Create an imported skill (no signature)
+  it('unsigned file labeled "imported" is rejected unless trusted', async () => {
+    // Security fix: `imported` provenance no longer bypasses verification.
     const skill = makeSkill('example.com', 'imported');
     await writeSkillFile(skill, testDir);
 
-    // Reading with verification should not fail for imported files
-    const loaded = await readSkillFile('example.com', testDir, { verifySignature: true, signingKey });
+    await assert.rejects(
+      () => readSkillFile('example.com', testDir, { verifySignature: true, signingKey }),
+      /unsigned/i,
+      'imported-but-unsigned file must not load silently',
+    );
 
-    assert.ok(loaded, 'Should load imported skill without verification error');
-    assert.equal(loaded.domain, 'example.com');
-    assert.equal(loaded.provenance, 'imported');
+    // It still loads when the caller explicitly trusts unsigned files.
+    const loaded = await readSkillFile('example.com', testDir, {
+      verifySignature: true,
+      signingKey,
+      trustUnsigned: true,
+    });
+    assert.ok(loaded, 'Should load with trustUnsigned');
   });
 
   it('verifies pre-March-5 skill files signed with legacy shallow canonicalization', async () => {

--- a/test/skill/store-verify.test.ts
+++ b/test/skill/store-verify.test.ts
@@ -54,6 +54,35 @@ describe('F4: Signature verification on load', () => {
     await rm(testDir, { recursive: true, force: true });
   });
 
+  it('fixed-salt (v0.2) legacy key fallback is gated behind APITAP_ALLOW_LEGACY_KEYS', async () => {
+    const { pbkdf2Sync } = await import('node:crypto');
+    const prevId = process.env.APITAP_MACHINE_ID;
+    const prevFlag = process.env.APITAP_ALLOW_LEGACY_KEYS;
+    process.env.APITAP_MACHINE_ID = 'fixed-salt-test-id';
+    try {
+      // A file signed with the public-constant v0.2 key (legacy canon).
+      const fixedSaltKey = pbkdf2Sync('fixed-salt-test-id', 'apitap-v0.2-key-derivation', 100_000, 32, 'sha512');
+      const legacy = signSkillLegacy(makeSkill('example.com'), fixedSaltKey);
+      await writeFile(join(testDir, 'example.com.json'), JSON.stringify(legacy));
+
+      // Default: the forgeable fixed-salt key must NOT verify the file.
+      delete process.env.APITAP_ALLOW_LEGACY_KEYS;
+      await assert.rejects(
+        () => readSkillFile('example.com', testDir, { verifySignature: true }),
+        /verification failed|tamper/i,
+        'fixed-salt fallback must be off by default',
+      );
+
+      // Opt-in: one-off migration of genuinely old files.
+      process.env.APITAP_ALLOW_LEGACY_KEYS = '1';
+      const loaded = await readSkillFile('example.com', testDir, { verifySignature: true });
+      assert.ok(loaded, 'should load with APITAP_ALLOW_LEGACY_KEYS=1');
+    } finally {
+      if (prevId === undefined) delete process.env.APITAP_MACHINE_ID; else process.env.APITAP_MACHINE_ID = prevId;
+      if (prevFlag === undefined) delete process.env.APITAP_ALLOW_LEGACY_KEYS; else process.env.APITAP_ALLOW_LEGACY_KEYS = prevFlag;
+    }
+  });
+
   it('verification fails for tampered skill file', async () => {
     // Create and sign a skill
     const skill = makeSkill('example.com');


### PR DESCRIPTION
Addresses the findings from a full security & privacy audit of the CLI, MCP server, native host, and browser extension. Seven commits, each scoped and TDD'd where unit-testable. **1581 tests pass**, typecheck clean, extension builds.

## Findings fixed

### Integrity (`fix: authenticate provenance…`)
- **H1** `provenance` is now part of the HMAC-signed payload, and the `imported` branch that skipped verification entirely is gone — relabelling a file no longer bypasses the signature check. Imported files are re-signed locally as `imported-signed` instead of being stored unsigned. Backward-compat verify fallback + transparent re-sign for older formats.
- **H2** `provenanceForSigning()` computes the minimum trust across endpoints, so a single imported endpoint can't make a merged file inherit `self` trust (replaces the buggy `.some()` at all five cli signing sites).

### SSRF (`fix: close IPv6-literal SSRF bypasses…`)
- **H4** All bracketed IPv6 literals route through `isPrivateIp` — `[::]` (→ loopback) no longer bypasses both layers; NAT64 (`64:ff9b::/96`) and deprecated site-local (`fec0::/10`) added.
- **H3** The capture verifier used the sync `validateUrl` (no DNS resolution) and followed redirects; now uses `resolveAndValidateUrl` + `redirect:'manual'`. Symmetric post-fetch DNS re-check added on replay redirect hops.

### Privacy (`fix: wire sensitive-path filter…`)
- **H5** `shouldCapture()` drops human PII / financial / account-security paths (password, 2fa, checkout, payment, billing, account/security) on the capture path. OAuth/token endpoints are intentionally left capturable — that's the auth subsystem (secret → encrypted store, scrubbed from skill).
- **H6** Scrubber gains Stripe/GitHub/Slack/GitLab key patterns, IBANs, IPv6 (pure browser-safe validator); `isSensitiveBodyKey()` catches camelCase/prefixed credential keys; query scrub adds OAuth `code`/`state`, password, etc. Index endpoint paths are scrubbed and `index.json` is written `0o600`.

### Secrets & egress (`fix: redirect header allowlist…`)
- Cross-domain redirects use a header **allowlist** (catches `X-Session`, `CF-Access-Jwt-Assertion` that the old token/secret/key blocklist missed).
- OAuth refresh errors redact `refresh_token`/`client_secret` before returning.
- The public-constant fixed-salt legacy signing key is gated behind `APITAP_ALLOW_LEGACY_KEYS=1` (forgeable on cloned machine-id fleets).
- `SECURITY.md` corrected to match reality (at-rest encryption is access-controlled by file perms, not safe if files are stolen).

### Supply chain (`fix: remove postpublish exec hook…`)
- Removed the `postpublish` `execSync` hook (footgun + redundant with `release.sh`).
- CI actions SHA-pinned; `permissions: contents: read` added.

### Native host + extension (`fix: harden native-host IPC…`)
- `capture_request` relay validates the domain before forwarding; socket created `0o600` atomically (umask before listen).
- Agent-initiated captures require per-capture consent (no silent 24h-cache reuse); `_relayId` validated.
- Passive index captures token **values** only for user-approved domains (metadata still indexed for all).
- Fixed consent-notification icon path.

### Robustness (`fix: fileURLToPath…`)
- `known-specs-loader` uses `fileURLToPath` (Windows / spaces safe).
- Broad `/token` OAuth detection requires a corroborating OAuth field before treating a body as a grant.

## Behavior changes to note before merge
- Legacy `imported`/unsigned skill files now need re-import or `--trust-unsigned`.
- Agent-initiated (CLI/MCP) captures now always prompt for consent.
- The TOCTOU/SNI residual (pin-IP-vs-SNI tradeoff) is left as documented; the pre+post DNS checks narrow it.
- A few extension/native-host changes (socket timing race, `handleAgentCapture`) are build-verified rather than unit-tested — those paths aren't deterministically unit-testable and lack a chrome-mock harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)