### PR TITLE
fix(capture): merge with existing skill on finish instead of overwriting (#55)

### DIFF
--- a/src/capture/session.ts
+++ b/src/capture/session.ts
@@ -7,8 +7,9 @@ import { isDomainMatch } from './domain.js';
 import { SkillGenerator, deduplicateAuth, type GeneratorOptions } from '../skill/generator.js';
 import { detectCaptcha } from '../auth/refresh.js';
 import { verifyEndpoints } from './verifier.js';
-import { signSkillFile } from '../skill/signing.js';
-import { writeSkillFile } from '../skill/store.js';
+import { signSkillFileAs, provenanceForSigning } from '../skill/signing.js';
+import { writeSkillFile, readSkillFile } from '../skill/store.js';
+import { mergeCapturedSkillFiles } from '../skill/merge.js';
 import { AuthManager, getMachineId } from '../auth/manager.js';
 import { deriveSigningKey } from '../auth/crypto.js';
 import { homedir } from 'node:os';
@@ -240,11 +241,24 @@ export class CaptureSession {
       // Verify endpoints
       skill = await verifyEndpoints(skill);
 
-      // Sign
-      skill = signSkillFile(skill, key);
+      // Merge with any existing on-disk skill so a re-capture ADDS to prior
+      // coverage instead of overwriting it (#55). Previously-captured endpoints
+      // not seen this session are carried over; the fresh capture wins on any
+      // endpoint re-seen. Read with trustUnsigned so a same-user file always
+      // merges; if it can't be read (corrupt/foreign signature), fall back to
+      // just this session's skill rather than failing the capture.
+      const skillsDir = this.options.skillsDir;
+      let existing = null;
+      try {
+        existing = await readSkillFile(domain, skillsDir, { trustUnsigned: true });
+      } catch { /* no existing or unreadable — proceed with fresh only */ }
+      skill = mergeCapturedSkillFiles(existing, skill).skillFile;
+
+      // Sign with minimum-trust provenance: 'self' for an all-captured file,
+      // 'imported-signed' if the merge carried in any imported endpoints.
+      skill = signSkillFileAs(skill, key, provenanceForSigning(skill));
 
       // Write
-      const skillsDir = this.options.skillsDir;
       const path = await writeSkillFile(skill, skillsDir);
 
       // Tally tiers

--- a/src/skill/merge.ts
+++ b/src/skill/merge.ts
@@ -21,6 +21,70 @@ function matchKey(method: string, path: string): string {
   return `${method.toUpperCase()} ${normalizePath(path)}`;
 }
 
+export interface CapturedMergeResult {
+  skillFile: SkillFile;
+  /** endpoints in `fresh` that did not exist in `existing` */
+  added: number;
+  /** endpoints present in both (re-captured this session — fresh won) */
+  updated: number;
+  /** endpoints in `existing` not re-captured this session (carried over) */
+  preserved: number;
+}
+
+/**
+ * Pure function — no I/O.
+ *
+ * Merge a freshly-captured skill file with the one already on disk for the same
+ * domain, so a new capture session ADDS to prior coverage instead of replacing
+ * it. Unlike {@link mergeSkillFile} (which treats its second argument as
+ * lower-priority OpenAPI spec data), here both sides are captured, so the FRESH
+ * capture wins on any endpoint re-seen this session (newest example/verification),
+ * while endpoints only present in the existing file are carried over untouched.
+ *
+ * Endpoints are matched by `METHOD + normalizePath(path)`, so the same route
+ * captured with a different param name (`:id` vs `:userId`) dedupes to one.
+ * The fresh file is used as the base (latest capturedAt / baseUrl / metadata);
+ * the existing file's `metadata.importHistory` is carried forward if present.
+ *
+ * @param existing The existing skill file on disk, or null if none exists.
+ * @param fresh    The skill file generated from the current capture session.
+ */
+export function mergeCapturedSkillFiles(
+  existing: SkillFile | null,
+  fresh: SkillFile,
+): CapturedMergeResult {
+  if (!existing) {
+    return { skillFile: fresh, added: fresh.endpoints.length, updated: 0, preserved: 0 };
+  }
+
+  const freshKeys = new Set(fresh.endpoints.map(ep => matchKey(ep.method, ep.path)));
+
+  // Start from the union: existing endpoints not re-captured, then all fresh.
+  const carriedOver = existing.endpoints.filter(
+    ep => !freshKeys.has(matchKey(ep.method, ep.path)),
+  );
+  const existingKeys = new Set(existing.endpoints.map(ep => matchKey(ep.method, ep.path)));
+
+  let added = 0;
+  let updated = 0;
+  for (const ep of fresh.endpoints) {
+    if (existingKeys.has(matchKey(ep.method, ep.path))) updated++;
+    else added++;
+  }
+
+  const merged: SkillFile = {
+    ...fresh,
+    endpoints: [...carriedOver, ...fresh.endpoints],
+  };
+
+  // Preserve import history from the prior file (capture doesn't produce it).
+  if (existing.metadata?.importHistory && !merged.metadata.importHistory) {
+    merged.metadata = { ...merged.metadata, importHistory: existing.metadata.importHistory };
+  }
+
+  return { skillFile: merged, added, updated, preserved: carriedOver.length };
+}
+
 /**
  * Merge query params from a captured endpoint with params from an imported
  * spec endpoint.

--- a/test/capture/session.test.ts
+++ b/test/capture/session.test.ts
@@ -253,6 +253,57 @@ describe('CaptureSession', () => {
     }
   });
 
+  it('finish() merges with an existing skill instead of overwriting it (#55)', async () => {
+    // Pre-seed an existing skill file for the capture domain with an endpoint
+    // the current session will NOT re-capture.
+    const { writeFile } = await import('node:fs/promises');
+    const preexisting = {
+      version: '1.2',
+      domain: 'localhost',
+      capturedAt: '2020-01-01T00:00:00.000Z',
+      baseUrl: 'http://localhost',
+      endpoints: [{
+        id: 'get-previously-captured',
+        method: 'GET',
+        path: '/api/previously-captured',
+        queryParams: {},
+        headers: {},
+        responseShape: { type: 'object', fields: ['ok'] },
+        examples: { request: { url: 'http://localhost/api/previously-captured', headers: {} }, responsePreview: null },
+      }],
+      metadata: { captureCount: 1, filteredCount: 0, toolVersion: '1.0.0' },
+      provenance: 'unsigned',
+    };
+    await writeFile(join(testDir, 'localhost.json'), JSON.stringify(preexisting), 'utf-8');
+
+    const session = new CaptureSession({ headless: true, skillsDir: testDir });
+    await session.start(baseUrl);
+    const snap = await session.interact({ action: 'snapshot' });
+    const btn = snap.snapshot.elements.find(e => e.tag === 'button' && e.text.includes('Load Data'));
+    if (btn) {
+      await session.interact({ action: 'click', ref: btn.ref });
+      await session.interact({ action: 'wait', seconds: 2 });
+    }
+    const result = await session.finish();
+
+    // The previously-captured endpoint must survive the new capture. Before the
+    // fix, finish() overwrote the file with only this session's endpoints.
+    const { readSkillFile } = await import('../../src/skill/store.js');
+    const loaded = await readSkillFile('localhost', testDir, { trustUnsigned: true });
+    assert.ok(loaded, 'skill file should still exist');
+    const ids = loaded!.endpoints.map(e => e.id);
+    assert.ok(ids.includes('get-previously-captured'), `preexisting endpoint must be preserved, got: ${ids.join(', ')}`);
+
+    // When this session actually captured an endpoint, the file is the union.
+    const localhostDomain = result.domains.find(d => d.domain === 'localhost');
+    if (localhostDomain) {
+      assert.ok(
+        loaded!.endpoints.length > 1,
+        'merged file should contain the preexisting endpoint plus the freshly captured one(s)',
+      );
+    }
+  });
+
   it('abort() closes without writing', async () => {
     const session = new CaptureSession({ headless: true, skillsDir: testDir });
     await session.start(baseUrl);

--- a/test/skill/merge.test.ts
+++ b/test/skill/merge.test.ts
@@ -1,7 +1,7 @@
 // test/skill/merge.test.ts
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizePath, mergeSkillFile } from '../../src/skill/merge.js';
+import { normalizePath, mergeSkillFile, mergeCapturedSkillFiles } from '../../src/skill/merge.js';
 import type { SkillEndpoint, SkillFile, ImportMeta } from '../../src/types.js';
 
 // ---- Helpers ----------------------------------------------------------------
@@ -406,5 +406,62 @@ describe('mergeSkillFile — query param merge', () => {
     );
     const result = mergeSkillFile(null, imported, testMeta);
     assert.equal(result.skillFile.endpoints.length, 500);
+  });
+});
+
+// ---- mergeCapturedSkillFiles (capture-to-capture union) ----------------------
+
+describe('mergeCapturedSkillFiles', () => {
+  it('returns the fresh skill unchanged when there is no existing file', () => {
+    const fresh = makeSkillFile([makeEndpoint({ id: 'a', path: '/a' })]);
+    const r = mergeCapturedSkillFiles(null, fresh);
+    assert.deepEqual(r.skillFile.endpoints.map(e => e.id), ['a']);
+    assert.deepEqual([r.added, r.updated, r.preserved], [1, 0, 0]);
+  });
+
+  it('preserves previously-captured endpoints not seen in the fresh session', () => {
+    const existing = makeSkillFile([
+      makeEndpoint({ id: 'a', method: 'GET', path: '/a' }),
+      makeEndpoint({ id: 'b', method: 'GET', path: '/b' }),
+    ]);
+    const fresh = makeSkillFile([makeEndpoint({ id: 'c', method: 'GET', path: '/c' })]);
+
+    const r = mergeCapturedSkillFiles(existing, fresh);
+    const ids = r.skillFile.endpoints.map(e => e.id).sort();
+    assert.deepEqual(ids, ['a', 'b', 'c'], 'union must keep a, b and add c');
+    assert.deepEqual([r.added, r.updated, r.preserved], [1, 0, 2]);
+  });
+
+  it('lets the fresh capture win on a re-captured endpoint (same method + path slot)', () => {
+    const existing = makeSkillFile([
+      makeEndpoint({ id: 'old-user', method: 'GET', path: '/users/:id',
+        examples: { request: { url: 'https://test.com/users/1', headers: {} }, responsePreview: null } }),
+    ]);
+    // same slot, different param name + fresher example
+    const fresh = makeSkillFile([
+      makeEndpoint({ id: 'new-user', method: 'GET', path: '/users/:userId',
+        examples: { request: { url: 'https://test.com/users/42', headers: {} }, responsePreview: { ok: true } } }),
+    ]);
+
+    const r = mergeCapturedSkillFiles(existing, fresh);
+    assert.equal(r.skillFile.endpoints.length, 1, 'same slot must dedupe, not duplicate');
+    assert.equal(r.skillFile.endpoints[0].id, 'new-user', 'fresh capture wins');
+    assert.deepEqual([r.added, r.updated, r.preserved], [0, 1, 0]);
+  });
+
+  it('treats different methods on the same path as distinct endpoints', () => {
+    const existing = makeSkillFile([makeEndpoint({ id: 'get-x', method: 'GET', path: '/x' })]);
+    const fresh = makeSkillFile([makeEndpoint({ id: 'post-x', method: 'POST', path: '/x' })]);
+    const r = mergeCapturedSkillFiles(existing, fresh);
+    assert.equal(r.skillFile.endpoints.length, 2);
+  });
+
+  it('uses the fresh file as the base (latest capturedAt / metadata)', () => {
+    const existing = makeSkillFile([makeEndpoint({ id: 'a', path: '/a' })]);
+    existing.capturedAt = '2020-01-01T00:00:00.000Z';
+    const fresh = makeSkillFile([makeEndpoint({ id: 'b', path: '/b' })]);
+    fresh.capturedAt = '2026-05-29T00:00:00.000Z';
+    const r = mergeCapturedSkillFiles(existing, fresh);
+    assert.equal(r.skillFile.capturedAt, '2026-05-29T00:00:00.000Z');
   });
 });


### PR DESCRIPTION
Fixes #55.

## Problem

`CaptureSession.finish()` built the skill from only the current session's captured exchanges and wrote it with `writeSkillFile()`, **wholesale-replacing** any existing on-disk skill for that domain. Re-capturing a domain — e.g. drilling into one resource's table view — silently dropped every endpoint captured in prior sessions (observed live: `api.dane.gov.pl` went 8 → 6 endpoints, losing `search`).

All capture entrypoints were affected since they share `finish()`: one-shot `apitap_capture`, interactive `apitap_capture_finish`, and the CLI `apitap capture`.

## Fix

`finish()` now reads the existing skill and unions it with the freshly-captured one before signing/writing, via a new **pure** helper `mergeCapturedSkillFiles()` in `src/skill/merge.ts`:

- Endpoints matched by `METHOD + normalizePath(path)` (so `:id` vs `:userId` slots dedupe to one).
- The **fresh** capture wins on any endpoint re-seen this session (newest example/verification); endpoints only in the existing file are carried over untouched.
- Fresh file is the base (latest `capturedAt` / `baseUrl` / metadata); existing `metadata.importHistory` is preserved.

This is distinct from the existing `mergeSkillFile()` (OpenAPI-import semantics, where captured data always wins over spec). Here both sides are captured, so freshness wins.

Read uses `trustUnsigned: true` and falls back to fresh-only if the existing file is unreadable, so a corrupt/foreign file never fails the capture. The merged file is signed with `provenanceForSigning()` (not always-`self`), so if the merge pulls in previously-imported endpoints it's labelled `imported-signed`.

## Tests

- `mergeCapturedSkillFiles` unit cases: null existing, preserve-unseen, fresh-wins-on-conflict, distinct-method-same-path, fresh-as-base.
- Live `CaptureSession` integration test: pre-seed a skill with an endpoint, run a capture that doesn't re-hit it, `finish()`, assert the pre-seeded endpoint survives (and the file is the union when the session captured anything). Fails on `main`, passes here.

Full suite: 1587 passing, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)