### PR TITLE
chore: de-flake CDP-attach CI test + normalize repository.url

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "BSL-1.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/n1byn1kt/apitap.git"
+    "url": "git+https://github.com/n1byn1kt/apitap.git"
   },
   "homepage": "https://github.com/n1byn1kt/apitap#readme",
   "bugs": {

--- a/test/capture/cdp-attach-integration.test.ts
+++ b/test/capture/cdp-attach-integration.test.ts
@@ -28,6 +28,11 @@ function cdpGet<T>(url: string): Promise<T> {
 
 describe('CDP attach integration', { skip: !chromeAvailable ? 'Chrome not installed' : undefined }, () => {
   let chrome: ChildProcess;
+  // Chrome being installed doesn't guarantee its remote-debugging port comes
+  // up — in constrained CI sandboxes the port sometimes never binds. Track
+  // readiness and skip (not fail) the tests when it doesn't, so this stays a
+  // signal about cdp-attach behavior rather than a flaky env check.
+  let cdpReady = false;
 
   before(async () => {
     chrome = spawn('google-chrome', [
@@ -40,6 +45,7 @@ describe('CDP attach integration', { skip: !chromeAvailable ? 'Chrome not instal
     for (let i = 0; i < 20; i++) {
       try {
         await cdpGet(`http://127.0.0.1:${TEST_PORT}/json/version`);
+        cdpReady = true;
         break;
       } catch {
         await new Promise(r => setTimeout(r, 500));
@@ -51,7 +57,11 @@ describe('CDP attach integration', { skip: !chromeAvailable ? 'Chrome not instal
     if (chrome) chrome.kill();
   });
 
-  it('discovers browser WebSocket URL and tab count', async () => {
+  it('discovers browser WebSocket URL and tab count', async (t) => {
+    if (!cdpReady) {
+      t.skip('Chrome remote-debugging port never became ready');
+      return;
+    }
     const { discoverBrowserWsUrl } = await import('../../src/capture/cdp-attach.js');
 
     const info = await discoverBrowserWsUrl(TEST_PORT);


### PR DESCRIPTION
Two small chores (the loose ends from the v1.12.1 release).

### 1. De-flake the CDP-attach integration test
`test/capture/cdp-attach-integration.test.ts` gates on `which google-chrome`, but Chrome being installed doesn't guarantee its `--remote-debugging-port` actually binds — in constrained CI sandboxes it intermittently doesn't, and the test failed with `connect ECONNREFUSED 127.0.0.1:9333` (the red CI on the v1.12.1 PR run). The `before()` hook already retried for ~10s but didn't record whether it succeeded, so the test ran regardless.

Now `before()` sets a `cdpReady` flag on success, and the test `t.skip()`s when the debug port never came up — so it stays a genuine signal about cdp-attach behavior instead of a flaky environment check. Passes normally where Chrome's debug port is reachable (incl. locally).

### 2. `npm pkg fix`
Normalizes `repository.url` (`https://…` → `git+https://…`), silencing the warning npm auto-corrects on every `npm publish`.

No behavior change to shipped code. Full suite: 1587 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)