### PR TITLE
fix: maxBytes honesty — recursive truncation with structured metadata + read envelope diet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- `maxBytes` now bounds replay responses at any nesting depth (wrapper objects,
+  GraphQL shapes). Previously nested payloads passed through untruncated.
+- `truncated` in replay/browse results is now a structured report
+  `{originalBytes, finalBytes, droppedItems, keptItems, note?}` instead of
+  `true`. It is still truthy exactly when truncation occurred.
+- Truncation never returns an empty array for non-empty input — worst case a
+  single shape-sample item with capped strings is kept.
+- `read` envelope: links are deduped by href and capped at 100 (`linksOmitted`
+  reports the cut); images are omitted by default (`--images` / `includeImages`
+  restores them, deduped and capped at 50); `cost.tokens` now measures the
+  whole envelope; `maxBytes` bounds the envelope, shrinking links before
+  content. `--no-scan` / `scan: false` preserves the legacy envelope exactly.
+
 ## v1.12.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,24 @@
 
 ### Changed
 - `maxBytes` now bounds replay responses at any nesting depth (wrapper objects,
-  GraphQL shapes). Previously nested payloads passed through untruncated.
-- `truncated` in replay/browse results is now a structured report
+  GraphQL shapes). Previously nested payloads passed through untruncated. The
+  bound is approximate, not exact: honest metadata and order-of-magnitude
+  correctness are the goal, and rare shapes (e.g. very wide flat objects of
+  small scalars) can still exceed it.
+- **BREAKING** for consumers that compare strictly: `truncated` in replay/browse
+  results is now a structured report
   `{originalBytes, finalBytes, droppedItems, keptItems, note?}` instead of
-  `true`. It is still truthy exactly when truncation occurred.
+  `true`. It is still truthy exactly when truncation occurred, so
+  `if (result.truncated)` keeps working — but `result.truncated === true`
+  checks and JSON schemas typing the field as `boolean` must be updated.
 - Truncation never returns an empty array for non-empty input — worst case a
   single shape-sample item with capped strings is kept.
 - `read` envelope: links are deduped by href and capped at 100 (`linksOmitted`
   reports the cut); images are omitted by default (`--images` / `includeImages`
   restores them, deduped and capped at 50); `cost.tokens` now measures the
-  whole envelope; `maxBytes` bounds the envelope, shrinking links before
-  content. `--no-scan` / `scan: false` preserves the legacy envelope exactly.
+  whole envelope; `maxBytes` shrinks links first and slices content, but the
+  bound is approximate — a large content body plus fixed metadata can exceed
+  it. `--no-scan` / `scan: false` preserves the legacy envelope exactly.
 
 ## v1.12.1
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -160,6 +160,7 @@ function printUsage(): void {
     --max-bytes <bytes>        Truncate content to fit within byte limit
     --scan                     Enable trap-aware content scanning (default)
     --no-scan                  Disable trap-aware content scanning
+    --images                   Include the images array (deduped, capped at 50)
 
   Import options:
     --yes                      Skip confirmation prompt
@@ -532,6 +533,7 @@ async function handleReplay(positional: string[], flags: Record<string, string |
     console.log(JSON.stringify({
       status: result.status,
       data: result.data,
+      ...(result.truncated ? { truncated: result.truncated } : {}),
       ...(result.contractWarnings?.length ? { contractWarnings: result.contractWarnings } : {}),
       ...(result.warnings?.length ? { warnings: result.warnings } : {}),
     }, null, 2));
@@ -2291,8 +2293,9 @@ async function handleRead(positional: string[], flags: Record<string, string | b
   }
 
   const scanFlag = flags['no-scan'] !== true;
+  const includeImages = flags['images'] === true;
 
-  const result = await read(fullUrl, { maxBytes, scan: scanFlag });
+  const result = await read(fullUrl, { maxBytes, scan: scanFlag, includeImages });
 
   if (!result) {
     if (json) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -550,6 +550,16 @@ async function handleReplay(positional: string[], flags: Record<string, string |
     }
     console.log(`\n  Status: ${result.status}\n`);
     console.log(JSON.stringify(result.data, null, 2));
+    if (result.truncated) {
+      const t = result.truncated;
+      const fromKb = Math.round(t.originalBytes / 1024);
+      const toKb = Math.round(t.finalBytes / 1024);
+      const itemsClause =
+        t.droppedItems === 0 && t.keptItems === 0
+          ? ''
+          : `kept ${t.keptItems} items, dropped ${t.droppedItems}, `;
+      console.log(`  truncated: ${itemsClause}${fromKb} KB → ${toKb} KB`);
+    }
     console.log();
   }
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -394,7 +394,12 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
             throw new Error(validation.reason ?? 'URL validation failed');
           }
         }
-        const result = await read(url, { maxBytes: maxBytes ?? undefined, scan: scan !== false, includeImages: includeImages === true });
+        const result = await read(url, {
+          maxBytes: maxBytes ?? undefined,
+          scan: scan !== false,
+          includeImages: includeImages === true,
+          skipSsrf: options._skipSsrfCheck,
+        });
         if (!result) {
           return {
             content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Failed to read content', url }) }],

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -235,7 +235,7 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
             skillSource,
             capturedAt: skill.capturedAt,
             ...(result.refreshed ? { refreshed: result.refreshed } : {}),
-            ...(result.truncated ? { truncated: true } : {}),
+            ...(result.truncated ? { truncated: result.truncated } : {}),
             ...(result.contractWarnings?.length ? { contractWarnings: result.contractWarnings } : {}),
           }, 'apitap_replay');
       } catch (err: any) {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -376,13 +376,14 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
         url: z.string().describe('URL to read (e.g. "https://en.wikipedia.org/wiki/TypeScript")'),
         maxBytes: z.number().optional().describe('Maximum content size in bytes. Content is truncated to fit.'),
         scan: z.boolean().optional().describe('Enable trap-aware content scanning (default: true). Set to false to skip scanning and preserve the legacy response envelope shape.'),
+        includeImages: z.boolean().optional().describe('Include the images array (deduped, capped at 50). Default: false.'),
       }),
       annotations: {
         readOnlyHint: true,
         openWorldHint: true,
       },
     },
-    async ({ url, maxBytes, scan }) => {
+    async ({ url, maxBytes, scan, includeImages }) => {
       if (!rateLimiter.check()) {
         return { content: [{ type: 'text' as const, text: 'Rate limit exceeded. Try again in a moment.' }], isError: true };
       }
@@ -393,7 +394,7 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
             throw new Error(validation.reason ?? 'URL validation failed');
           }
         }
-        const result = await read(url, { maxBytes: maxBytes ?? undefined, scan: scan !== false });
+        const result = await read(url, { maxBytes: maxBytes ?? undefined, scan: scan !== false, includeImages: includeImages === true });
         if (!result) {
           return {
             content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Failed to read content', url }) }],

--- a/src/orchestration/browse.ts
+++ b/src/orchestration/browse.ts
@@ -1,4 +1,5 @@
 import type { SkillFile, SkillEndpoint } from '../types.js';
+import type { TruncationInfo } from '../replay/truncate.js';
 import { readSkillFile } from '../skill/store.js';
 import { replayEndpoint } from '../replay/engine.js';
 import { SessionCache } from './cache.js';
@@ -33,7 +34,7 @@ export interface BrowseSuccess {
   skillSource: 'disk' | 'discovered' | 'captured' | 'bridge';
   capturedAt: string;
   task?: string;
-  truncated?: boolean;
+  truncated?: TruncationInfo;
 }
 
 export interface BrowseGuidance {
@@ -106,7 +107,7 @@ async function tryBridgeCapture(
               skillSource: 'bridge',
               capturedAt: primarySkill.capturedAt ?? new Date().toISOString(),
               task: options.task,
-              ...(replayResult.truncated ? { truncated: true } : {}),
+              ...(replayResult.truncated ? { truncated: replayResult.truncated } : {}),
             };
           }
         } catch {
@@ -343,7 +344,7 @@ export async function browse(
       skillSource,
       capturedAt: skill.capturedAt,
       task,
-      ...(result.truncated ? { truncated: true } : {}),
+      ...(result.truncated ? { truncated: result.truncated } : {}),
     };
   } catch {
     // Try extension bridge before giving up

--- a/src/read/index.ts
+++ b/src/read/index.ts
@@ -12,6 +12,9 @@ import { appendFinding } from '../trapaware/audit.js';
 
 export interface ReadOptions {
   skipSsrf?: boolean;
+  /** Approximate envelope size bound: content is sliced to this many chars
+   *  and links shrink to fit, but content + fixed metadata keep priority and
+   *  can exceed it. */
   maxBytes?: number;
   /** Enable trap-aware content scanning on fetched HTML. Default: true.
    *  When false, the scanner does not run and the ReadResult has no

--- a/src/read/index.ts
+++ b/src/read/index.ts
@@ -33,7 +33,7 @@ function dietLinks(links: Array<{ text: string; href: string }>): Array<{ text: 
     let text = link.text;
     const imgMd = /^!\[(.*?)\]\(.*\)$/.exec(text);
     if (imgMd) text = imgMd[1];
-    if (text.trim() === '') continue; // image link with no alt: drop
+    if (text.trim() === '') continue; // no visible text after image-markdown unwrapping: drop
     out.push({ text, href: link.href });
   }
   return out;
@@ -141,8 +141,8 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
   }
 
   const dietedLinks = dietLinks(body.links);
-  let links = dietedLinks.slice(0, LINKS_CAP);
-  let linksOmitted = body.links.length - links.length;
+  const links = dietedLinks.slice(0, LINKS_CAP);
+  const linksOmitted = body.links.length - links.length;
 
   const images = options.includeImages ? dietImages(body.images) : [];
   const imagesOmitted = body.images.length - images.length;

--- a/src/read/index.ts
+++ b/src/read/index.ts
@@ -17,6 +17,39 @@ export interface ReadOptions {
    *  When false, the scanner does not run and the ReadResult has no
    *  `findings` field (byte-identical to pre-v1.0 output). */
   scan?: boolean;
+  /** Include the images array in the envelope (deduped, capped). Default: false. */
+  includeImages?: boolean;
+}
+
+const LINKS_CAP = 100;
+const IMAGES_CAP = 50;
+
+function dietLinks(links: Array<{ text: string; href: string }>): Array<{ text: string; href: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ text: string; href: string }> = [];
+  for (const link of links) {
+    if (seen.has(link.href)) continue;
+    seen.add(link.href);
+    let text = link.text;
+    const imgMd = /^!\[(.*?)\]\(.*\)$/.exec(text);
+    if (imgMd) text = imgMd[1];
+    if (text.trim() === '') continue; // image link with no alt: drop
+    out.push({ text, href: link.href });
+  }
+  return out;
+}
+
+function dietImages(images: Array<{ alt: string; src: string }>): Array<{ alt: string; src: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ alt: string; src: string }> = [];
+  for (const image of images) {
+    const key = image.src.split('?')[0]; // kill responsive-crop duplicates
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(image);
+    if (out.length >= IMAGES_CAP) break;
+  }
+  return out;
 }
 
 /**
@@ -85,14 +118,45 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
 
   const title = head.ogTitle || head.title || null;
 
-  return {
+  const legacy = !scanEnabled;
+
+  if (legacy) {
+    return {
+      url,
+      title,
+      author: head.author || null,
+      description: head.ogDescription || null,
+      content,
+      links: body.links,
+      images: body.images,
+      metadata: {
+        type: head.ogType || 'unknown',
+        publishedAt: head.publishedTime || null,
+        source,
+        canonical: head.canonical || null,
+        siteName: head.ogSiteName || null,
+      },
+      cost: { tokens: Math.ceil(content.length / 4) },
+    };
+  }
+
+  const dietedLinks = dietLinks(body.links);
+  let links = dietedLinks.slice(0, LINKS_CAP);
+  let linksOmitted = body.links.length - links.length;
+
+  const images = options.includeImages ? dietImages(body.images) : [];
+  const imagesOmitted = body.images.length - images.length;
+
+  const envelope: ReadResult = {
     url,
     title,
     author: head.author || null,
     description: head.ogDescription || null,
     content,
-    links: body.links,
-    images: body.images,
+    links,
+    ...(linksOmitted > 0 ? { linksOmitted } : {}),
+    images,
+    ...(imagesOmitted > 0 ? { imagesOmitted } : {}),
     metadata: {
       type: head.ogType || 'unknown',
       publishedAt: head.publishedTime || null,
@@ -100,7 +164,22 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
       canonical: head.canonical || null,
       siteName: head.ogSiteName || null,
     },
-    cost: { tokens: Math.ceil(content.length / 4) },
+    cost: { tokens: 0 },
     ...(findings !== undefined ? { findings } : {}),
   };
+
+  // maxBytes bounds the envelope: shrink links (halving) before touching content.
+  if (options.maxBytes) {
+    while (
+      Buffer.byteLength(JSON.stringify(envelope), 'utf-8') > options.maxBytes &&
+      envelope.links.length > 0
+    ) {
+      const keep = Math.floor(envelope.links.length / 2);
+      envelope.linksOmitted = (envelope.linksOmitted ?? 0) + (envelope.links.length - keep);
+      envelope.links = envelope.links.slice(0, keep);
+    }
+  }
+
+  envelope.cost = { tokens: Math.ceil(JSON.stringify(envelope).length / 4) };
+  return envelope;
 }

--- a/src/read/types.ts
+++ b/src/read/types.ts
@@ -21,6 +21,10 @@ export interface ReadResult {
   content: string;
   links: Array<{ text: string; href: string }>;
   images: Array<{ alt: string; src: string }>;
+  /** Number of links dropped by dedupe/caps. Absent on the legacy (scan: false) path. */
+  linksOmitted?: number;
+  /** Number of images dropped (all of them unless includeImages). Absent on the legacy path. */
+  imagesOmitted?: number;
   metadata: {
     type: string;
     publishedAt: string | null;

--- a/src/replay/engine.ts
+++ b/src/replay/engine.ts
@@ -4,7 +4,7 @@ import type { AuthManager } from '../auth/manager.js';
 import { substituteBodyVariables } from '../capture/body-variables.js';
 import { parseJwtClaims } from '../capture/entropy.js';
 import { refreshTokens } from '../auth/refresh.js';
-import { truncateResponse } from './truncate.js';
+import { truncateResponse, type TruncationInfo } from './truncate.js';
 import { resolveAndValidateUrl } from '../skill/ssrf.js';
 import { snapshotSchema } from '../contract/schema.js';
 import { diffSchema, type ContractWarning } from '../contract/diff.js';
@@ -81,8 +81,8 @@ export interface ReplayResult {
   data: unknown;
   /** Whether tokens were refreshed during this replay */
   refreshed?: boolean;
-  /** Whether the response was truncated to fit maxBytes */
-  truncated?: boolean;
+  /** Truncation report, present when the response was cut to fit maxBytes */
+  truncated?: TruncationInfo;
   /** Contract warnings from schema drift detection */
   contractWarnings?: ContractWarning[];
   /** Upgrade hint: set when a low-confidence endpoint gets a 2xx response */
@@ -685,7 +685,7 @@ export async function replayEndpoint(
           headers: retryHeaders,
           data: truncated.data,
           refreshed,
-          ...(truncated.truncated ? { truncated: true } : {}),
+          ...(truncated.truncated ? { truncated: truncated.truncated } : {}),
           ...(retryUpgrade ? { upgrade: retryUpgrade } : {}),
           ...(egressFindings && egressFindings.length > 0 ? { warnings: egressFindings } : {}),
         };
@@ -743,7 +743,7 @@ export async function replayEndpoint(
       headers: responseHeaders,
       data: truncated.data,
       ...(refreshed ? { refreshed } : {}),
-      ...(truncated.truncated ? { truncated: true } : {}),
+      ...(truncated.truncated ? { truncated: truncated.truncated } : {}),
       ...(contractWarnings ? { contractWarnings } : {}),
       ...(upgrade ? { upgrade } : {}),
       ...(egressFindings && egressFindings.length > 0 ? { warnings: egressFindings } : {}),
@@ -777,7 +777,7 @@ export interface BatchReplayResult {
   error?: string;
   tier?: string;
   capturedAt?: string;
-  truncated?: boolean;
+  truncated?: TruncationInfo;
   contractWarnings?: ContractWarning[];
   skillSource?: 'disk' | 'discovered' | 'captured';
 }
@@ -842,7 +842,7 @@ export async function replayMultiple(
           tier,
           capturedAt: skill.capturedAt,
           skillSource: 'disk',
-          ...(result.truncated ? { truncated: true } : {}),
+          ...(result.truncated ? { truncated: result.truncated } : {}),
           ...(result.contractWarnings?.length ? { contractWarnings: result.contractWarnings } : {}),
         };
       } catch (err: any) {

--- a/src/replay/truncate.ts
+++ b/src/replay/truncate.ts
@@ -170,6 +170,16 @@ export function truncateResponse(data: unknown, options?: TruncateOptions): Trun
   if (size(result) > 2 * maxBytes) {
     result = schemaSample(data, 0);
     stats.note = 'response exceeded budget after truncation; schema sample returned';
+    // The walk's dropped/kept counts describe the discarded truncateValue
+    // attempt, not this sample — recompute honestly for the sample we
+    // actually return.
+    if (Array.isArray(data)) {
+      const sampleKept = Array.isArray(result) ? result.length : 0;
+      stats.keptItems = sampleKept;
+      stats.droppedItems = Math.max(data.length - sampleKept, 0);
+    } else {
+      stats.keptItems = Array.isArray(result) ? result.length : 0;
+    }
   }
 
   return {

--- a/src/replay/truncate.ts
+++ b/src/replay/truncate.ts
@@ -127,8 +127,10 @@ function truncateValue(value: unknown, budget: number, depth: number, stats: Wal
  * worst case the caller gets one shape-sample item with capped strings.
  *
  * The result may overshoot maxBytes by per-level overhead; if it exceeds
- * 2 x maxBytes a schema-sample fallback replaces it. Exact byte fitting
- * is not a goal — honesty and order-of-magnitude correctness are.
+ * 2 x maxBytes a schema-sample fallback replaces it. The fallback keeps
+ * every key of a flat object, so a very wide object of small scalars can
+ * still exceed the bound. Exact byte fitting is not a goal — honesty and
+ * order-of-magnitude correctness are.
  */
 export function truncateResponse(data: unknown, options?: TruncateOptions): TruncateResult {
   let maxBytes = options?.maxBytes ?? DEFAULT_MAX_BYTES;

--- a/src/replay/truncate.ts
+++ b/src/replay/truncate.ts
@@ -4,99 +4,137 @@ export interface TruncateOptions {
   maxBytes?: number; // default 50000 (50KB)
 }
 
+/** Structured truncation report. Present (truthy) only when data was cut. */
+export interface TruncationInfo {
+  originalBytes: number;
+  finalBytes: number;
+  /** Total array items removed, summed across all nesting levels. */
+  droppedItems: number;
+  /** Items surviving in the largest truncated array. */
+  keptItems: number;
+  note?: string;
+}
+
 export interface TruncateResult {
   data: unknown;
-  truncated: boolean;
+  truncated: TruncationInfo | false;
 }
 
 const DEFAULT_MAX_BYTES = 50_000;
 const STRING_CAP = 500;
+const MAX_DEPTH = 32;
+const MIN_FIELD_BUDGET = 64;
 
 function byteLength(s: string): number {
   return Buffer.byteLength(s, 'utf-8');
 }
 
-/**
- * Truncate long string fields in an object, largest-first, until
- * the serialized size is under maxBytes.
- */
-function truncateObjectStrings(obj: Record<string, unknown>, maxBytes: number): Record<string, unknown> {
-  const result = { ...obj };
+function size(value: unknown): number {
+  const s = JSON.stringify(value);
+  return byteLength(s === undefined ? 'null' : s);
+}
 
-  // Collect string fields with their lengths
-  const stringFields: { key: string; len: number }[] = [];
-  for (const [key, val] of Object.entries(result)) {
-    if (typeof val === 'string' && val.length > STRING_CAP) {
-      stringFields.push({ key, len: val.length });
+interface WalkStats {
+  droppedItems: number;
+  keptItems: number;
+  note?: string;
+}
+
+function capString(value: string): string {
+  return value.length > STRING_CAP ? value.slice(0, STRING_CAP) + '... [truncated]' : value;
+}
+
+/** Aggressive last-resort shape sample: structure survives, bulk does not. */
+function schemaSample(value: unknown, depth: number): unknown {
+  if (depth > MAX_DEPTH) return '[truncated: depth]';
+  if (typeof value === 'string') return value.length > 100 ? value.slice(0, 100) + '... [truncated]' : value;
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    return value.length === 0 ? [] : [schemaSample(value[0], depth + 1)];
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = schemaSample(v, depth + 1);
+  }
+  return out;
+}
+
+function truncateValue(value: unknown, budget: number, depth: number, stats: WalkStats): unknown {
+  if (typeof value === 'string') return capString(value);
+  if (value === null || typeof value !== 'object') return value;
+  if (depth > MAX_DEPTH) return '[truncated: depth]';
+  if (size(value) <= budget) return value;
+
+  if (Array.isArray(value)) {
+    const arr = [...value];
+    while (arr.length > 1 && size(arr) > budget) {
+      arr.pop();
+      stats.droppedItems++;
     }
+    if (arr.length >= 1 && size(arr) > budget) {
+      // Single item still over budget: recurse into it, never drop to [].
+      arr[0] = truncateValue(arr[0], Math.max(budget - 2, MIN_FIELD_BUDGET), depth + 1, stats);
+      if (!stats.note) stats.note = 'single item exceeded budget; strings capped';
+    }
+    stats.keptItems = Math.max(stats.keptItems, arr.length);
+    return arr;
   }
 
-  // Sort largest first
-  stringFields.sort((a, b) => b.len - a.len);
-
-  for (const { key } of stringFields) {
-    const val = result[key] as string;
-    result[key] = val.slice(0, STRING_CAP) + '... [truncated]';
-    if (byteLength(JSON.stringify(result)) <= maxBytes) break;
+  // Object: recurse into dominant fields, largest first. Small scalar
+  // fields are never dropped — they are the schema the agent needs.
+  const record = value as Record<string, unknown>;
+  const result: Record<string, unknown> = { ...record };
+  const fields = Object.entries(record)
+    .map(([k, v]) => ({ k, v, s: size(v) }))
+    .sort((a, b) => b.s - a.s);
+  for (const field of fields) {
+    if (size(result) <= budget) break;
+    if (typeof field.v === 'string') {
+      result[field.k] = capString(field.v);
+    } else if (field.v !== null && typeof field.v === 'object') {
+      const others = size(result) - field.s;
+      const fieldBudget = Math.max(budget - others, MIN_FIELD_BUDGET);
+      result[field.k] = truncateValue(field.v, fieldBudget, depth + 1, stats);
+    }
+    // numbers/booleans/null: nothing to shrink
   }
-
   return result;
 }
 
 /**
  * Truncate a response to fit within maxBytes when serialized as JSON.
  *
- * - Arrays: remove items from the end until it fits. If a single item
- *   exceeds the limit, truncate long string fields within that item.
- * - Objects: truncate long string fields largest-first.
- * - Primitives/strings: returned as-is (or sliced if string).
+ * Recursive budget-spending walk: recurses into whichever fields dominate
+ * serialized size, drops array items from the end at any depth, and caps
+ * long strings. Never returns an empty container for non-empty input —
+ * worst case the caller gets one shape-sample item with capped strings.
+ *
+ * The result may overshoot maxBytes by per-level overhead; if it exceeds
+ * 2 x maxBytes a schema-sample fallback replaces it. Exact byte fitting
+ * is not a goal — honesty and order-of-magnitude correctness are.
  */
 export function truncateResponse(data: unknown, options?: TruncateOptions): TruncateResult {
-  const maxBytes = options?.maxBytes ?? DEFAULT_MAX_BYTES;
+  let maxBytes = options?.maxBytes ?? DEFAULT_MAX_BYTES;
+  if (!Number.isFinite(maxBytes) || maxBytes <= 0) maxBytes = DEFAULT_MAX_BYTES;
 
   if (data === null || data === undefined) {
     return { data, truncated: false };
   }
 
-  const serialized = JSON.stringify(data);
-  if (byteLength(serialized) <= maxBytes) {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(data) ?? 'null';
+  } catch {
+    // Cyclic input (impossible for JSON.parse output) — return unmodified.
+    return { data, truncated: false };
+  }
+  const originalBytes = byteLength(serialized);
+  if (originalBytes <= maxBytes) {
     return { data, truncated: false };
   }
 
-  // Array truncation
-  if (Array.isArray(data)) {
-    const arr = [...data];
-
-    // Remove items from the end until it fits
-    while (arr.length > 1 && byteLength(JSON.stringify(arr)) > maxBytes) {
-      arr.pop();
-    }
-
-    // If single item still exceeds limit, truncate strings within it
-    if (arr.length === 1 && byteLength(JSON.stringify(arr)) > maxBytes) {
-      const item = arr[0];
-      if (item && typeof item === 'object' && !Array.isArray(item)) {
-        arr[0] = truncateObjectStrings(item as Record<string, unknown>, maxBytes);
-      }
-    }
-
-    // If still over (e.g. array of primitives), return empty array
-    if (arr.length === 1 && byteLength(JSON.stringify(arr)) > maxBytes) {
-      return { data: [], truncated: true };
-    }
-
-    return { data: arr, truncated: true };
-  }
-
-  // Object truncation
-  if (typeof data === 'object') {
-    const result = truncateObjectStrings(data as Record<string, unknown>, maxBytes);
-    return { data: result, truncated: true };
-  }
-
-  // String truncation as last resort
+  // Top-level string: binary-search slice (cheap and exact).
   if (typeof data === 'string') {
-    // Binary search for the right length
     let lo = 0;
     let hi = data.length;
     const suffix = '... [truncated]';
@@ -108,9 +146,40 @@ export function truncateResponse(data: unknown, options?: TruncateOptions): Trun
         hi = mid - 1;
       }
     }
-    return { data: data.slice(0, lo) + suffix, truncated: true };
+    const sliced = data.slice(0, lo) + suffix;
+    return {
+      data: sliced,
+      truncated: {
+        originalBytes,
+        finalBytes: byteLength(JSON.stringify(sliced)),
+        droppedItems: 0,
+        keptItems: 0,
+      },
+    };
   }
 
-  // Numbers, booleans — can't truncate further
-  return { data, truncated: false };
+  if (typeof data !== 'object') {
+    // Oversized number/boolean cannot exist; nothing to do.
+    return { data, truncated: false };
+  }
+
+  const stats: WalkStats = { droppedItems: 0, keptItems: 0 };
+  let result = truncateValue(data, maxBytes, 0, stats);
+
+  // Safety net: bounded overshoot guarantee.
+  if (size(result) > 2 * maxBytes) {
+    result = schemaSample(data, 0);
+    stats.note = 'response exceeded budget after truncation; schema sample returned';
+  }
+
+  return {
+    data: result,
+    truncated: {
+      originalBytes,
+      finalBytes: size(result),
+      droppedItems: stats.droppedItems,
+      keptItems: stats.keptItems,
+      ...(stats.note ? { note: stats.note } : {}),
+    },
+  };
 }

--- a/src/replay/truncate.ts
+++ b/src/replay/truncate.ts
@@ -44,6 +44,23 @@ function capString(value: string): string {
   return value.length > STRING_CAP ? value.slice(0, STRING_CAP) + '... [truncated]' : value;
 }
 
+/** Largest array length found anywhere in a value (schemaSample caps every array to <= 1). */
+function maxArrayLength(value: unknown): number {
+  if (Array.isArray(value)) {
+    let max = value.length;
+    for (const item of value) max = Math.max(max, maxArrayLength(item));
+    return max;
+  }
+  if (value !== null && typeof value === 'object') {
+    let max = 0;
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      max = Math.max(max, maxArrayLength(v));
+    }
+    return max;
+  }
+  return 0;
+}
+
 /** Aggressive last-resort shape sample: structure survives, bulk does not. */
 function schemaSample(value: unknown, depth: number): unknown {
   if (depth > MAX_DEPTH) return '[truncated: depth]';
@@ -172,13 +189,13 @@ export function truncateResponse(data: unknown, options?: TruncateOptions): Trun
     stats.note = 'response exceeded budget after truncation; schema sample returned';
     // The walk's dropped/kept counts describe the discarded truncateValue
     // attempt, not this sample — recompute honestly for the sample we
-    // actually return.
+    // actually return. keptItems is the largest array surviving anywhere
+    // in the sample (schemaSample caps every array to <= 1 element), not
+    // just a top-level array — a nested array can survive even when the
+    // top level is an object.
+    stats.keptItems = maxArrayLength(result);
     if (Array.isArray(data)) {
-      const sampleKept = Array.isArray(result) ? result.length : 0;
-      stats.keptItems = sampleKept;
-      stats.droppedItems = Math.max(data.length - sampleKept, 0);
-    } else {
-      stats.keptItems = Array.isArray(result) ? result.length : 0;
+      stats.droppedItems = Math.max(data.length - stats.keptItems, 0);
     }
   }
 

--- a/test/cli/replay-truncation-summary.test.ts
+++ b/test/cli/replay-truncation-summary.test.ts
@@ -1,0 +1,43 @@
+// test/cli/replay-truncation-summary.test.ts
+// Verifies the human-readable (non --json) truncation summary line from handleReplay
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('CLI replay human-readable truncation summary', () => {
+  // Mirrors the formatting logic in handleReplay's non-JSON branch (src/cli.ts)
+  function formatTruncationSummary(t: {
+    originalBytes: number;
+    finalBytes: number;
+    droppedItems: number;
+    keptItems: number;
+  }): string {
+    const fromKb = Math.round(t.originalBytes / 1024);
+    const toKb = Math.round(t.finalBytes / 1024);
+    const itemsClause =
+      t.droppedItems === 0 && t.keptItems === 0
+        ? ''
+        : `kept ${t.keptItems} items, dropped ${t.droppedItems}, `;
+    return `  truncated: ${itemsClause}${fromKb} KB → ${toKb} KB`;
+  }
+
+  it('formats item-based truncation with KB rounding', () => {
+    const line = formatTruncationSummary({
+      originalBytes: 308_224,
+      finalBytes: 49_152,
+      droppedItems: 4988,
+      keptItems: 12,
+    });
+    assert.equal(line, '  truncated: kept 12 items, dropped 4988, 301 KB → 48 KB');
+  });
+
+  it('omits the items clause for plain string truncation (both counts zero)', () => {
+    const line = formatTruncationSummary({
+      originalBytes: 2048,
+      finalBytes: 1024,
+      droppedItems: 0,
+      keptItems: 0,
+    });
+    assert.equal(line, '  truncated: 2 KB → 1 KB');
+  });
+});

--- a/test/mcp/mcp.test.ts
+++ b/test/mcp/mcp.test.ts
@@ -330,4 +330,25 @@ describe('apitap_read via MCP', () => {
     assert.equal((result as any)._meta?.externalContent?.untrusted, true);
     assert.equal((result as any)._meta?.externalContent?.source, 'apitap_read');
   });
+
+  it('apitap_read forwards includeImages to read()', async () => {
+    // techcrunch.com is not decoder-matched (generic HTML pipeline), so it
+    // exercises the includeImages diet path rather than a site decoder.
+    const result = await client.callTool({
+      name: 'apitap_read',
+      arguments: { url: 'https://techcrunch.com', includeImages: true },
+    });
+    assert.equal(result.isError, undefined);
+    const data = JSON.parse((result.content as any)[0].text);
+    assert.ok(Array.isArray(data.images));
+    assert.ok(data.images.length > 0, 'images array should be non-empty when includeImages is true');
+
+    const withoutFlag = await client.callTool({
+      name: 'apitap_read',
+      arguments: { url: 'https://techcrunch.com' },
+    });
+    assert.equal(withoutFlag.isError, undefined);
+    const dataWithoutFlag = JSON.parse((withoutFlag.content as any)[0].text);
+    assert.deepEqual(dataWithoutFlag.images, []);
+  });
 });

--- a/test/mcp/mcp.test.ts
+++ b/test/mcp/mcp.test.ts
@@ -1,5 +1,5 @@
 // test/mcp/mcp.test.ts
-import { describe, it, beforeEach, afterEach } from 'node:test';
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -330,25 +330,73 @@ describe('apitap_read via MCP', () => {
     assert.equal((result as any)._meta?.externalContent?.untrusted, true);
     assert.equal((result as any)._meta?.externalContent?.source, 'apitap_read');
   });
+});
 
-  it('apitap_read forwards includeImages to read()', async () => {
-    // techcrunch.com is not decoder-matched (generic HTML pipeline), so it
-    // exercises the includeImages diet path rather than a site decoder.
+describe('apitap_read includeImages via MCP (hermetic)', () => {
+  let httpServer: Server;
+  let base: string;
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  before(async () => {
+    // Several <img> tags share a URL-sans-query to exercise dedupe.
+    const html = `<!doctype html><html><head><title>Fixture</title></head><body><article>
+      <p>${'Real content. '.repeat(100)}</p>
+      <img src="/img/1.jpg?w=100" alt="one">
+      <img src="/img/1.jpg?w=200" alt="one-dup">
+      <img src="/img/2.jpg" alt="two">
+      <img src="/img/3.jpg" alt="three">
+    </article></body></html>`;
+    httpServer = createHttpServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end(html);
+    });
+    await new Promise<void>(resolve => httpServer.listen(0, '127.0.0.1', resolve));
+    const port = (httpServer.address() as AddressInfo).port;
+    base = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>(resolve => httpServer.close(() => resolve()));
+  });
+
+  beforeEach(async () => {
+    const server = createMcpServer({ _skipSsrfCheck: true });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'test-client', version: '1.0.0' });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    cleanup = async () => {
+      await client.close();
+      await server.close();
+    };
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it('omits images by default with imagesOmitted > 0', async () => {
     const result = await client.callTool({
       name: 'apitap_read',
-      arguments: { url: 'https://techcrunch.com', includeImages: true },
+      arguments: { url: `${base}/page` },
+    });
+    assert.equal(result.isError, undefined);
+    const data = JSON.parse((result.content as any)[0].text);
+    assert.deepEqual(data.images, []);
+    assert.ok(data.imagesOmitted > 0, `expected imagesOmitted > 0, got ${data.imagesOmitted}`);
+  });
+
+  it('forwards includeImages to read(), returning deduped images', async () => {
+    const result = await client.callTool({
+      name: 'apitap_read',
+      arguments: { url: `${base}/page`, includeImages: true },
     });
     assert.equal(result.isError, undefined);
     const data = JSON.parse((result.content as any)[0].text);
     assert.ok(Array.isArray(data.images));
     assert.ok(data.images.length > 0, 'images array should be non-empty when includeImages is true');
-
-    const withoutFlag = await client.callTool({
-      name: 'apitap_read',
-      arguments: { url: 'https://techcrunch.com' },
-    });
-    assert.equal(withoutFlag.isError, undefined);
-    const dataWithoutFlag = JSON.parse((withoutFlag.content as any)[0].text);
-    assert.deepEqual(dataWithoutFlag.images, []);
+    // /img/1.jpg?w=100 and /img/1.jpg?w=200 dedupe to a single URL-sans-query entry.
+    assert.equal(data.images.length, 3, `expected 3 deduped images, got ${data.images.length}`);
   });
 });

--- a/test/read/envelope-diet.test.ts
+++ b/test/read/envelope-diet.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { createServer, type Server } from 'node:http';
+import { read } from '../../src/read/index.js';
+
+function pageWithNoise(): string {
+  const links = Array.from({ length: 300 }, (_, i) =>
+    `<a href="/story/${i % 120}">Story ${i % 120}</a>`).join('\n');
+  const images = Array.from({ length: 40 }, (_, i) =>
+    `<img src="/img/${i % 10}.jpg?w=${100 + i}" alt="pic ${i % 10}">`).join('\n');
+  return `<!doctype html><html><head><title>Noise</title></head><body><article><p>${'Real content. '.repeat(100)}</p>${links}${images}</article></body></html>`;
+}
+
+describe('read envelope diet', () => {
+  let server: Server;
+  let base: string;
+
+  before(async () => {
+    server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end(pageWithNoise());
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+    const addr = server.address() as { port: number };
+    base = `http://127.0.0.1:${addr.port}`;
+  });
+
+  after(() => server.close());
+
+  it('dedupes links by href and caps at 100 with linksOmitted', async () => {
+    const result = await read(`${base}/page`, { skipSsrf: true });
+    assert.ok(result);
+    const hrefs = result.links.map((l) => l.href);
+    assert.strictEqual(new Set(hrefs).size, hrefs.length, 'links must be unique by href');
+    assert.ok(result.links.length <= 100);
+    assert.ok((result.linksOmitted ?? 0) > 0);
+  });
+
+  it('omits images by default with imagesOmitted count', async () => {
+    const result = await read(`${base}/page`, { skipSsrf: true });
+    assert.ok(result);
+    assert.deepStrictEqual(result.images, []);
+    assert.ok((result.imagesOmitted ?? 0) > 0);
+  });
+
+  it('includeImages restores images deduped by URL-sans-query', async () => {
+    const result = await read(`${base}/page`, { skipSsrf: true, includeImages: true });
+    assert.ok(result);
+    assert.ok(result.images.length > 0 && result.images.length <= 10, `got ${result.images.length}`);
+  });
+
+  it('computes cost.tokens over the whole envelope', async () => {
+    const result = await read(`${base}/page`, { skipSsrf: true });
+    assert.ok(result);
+    const envelopeTokens = Math.ceil(JSON.stringify(result).length / 4);
+    assert.ok(result.cost.tokens >= envelopeTokens * 0.8, `${result.cost.tokens} vs ${envelopeTokens}`);
+  });
+
+  it('maxBytes bounds the envelope by shrinking links, content first-class', async () => {
+    const result = await read(`${base}/page`, { skipSsrf: true, maxBytes: 3000 });
+    assert.ok(result);
+    const bytes = Buffer.byteLength(JSON.stringify(result), 'utf-8');
+    assert.ok(bytes <= 6000, `envelope ${bytes} bytes`);
+    assert.ok(result.content.length > 0, 'content survives before links');
+  });
+
+  it('scan:false keeps the legacy envelope (no diet)', async () => {
+    const result = await read(`${base}/page`, { skipSsrf: true, scan: false });
+    assert.ok(result);
+    assert.ok(result.links.length > 100, 'legacy path must not cap links');
+    assert.ok(result.images.length > 0, 'legacy path must keep images');
+    assert.strictEqual(result.linksOmitted, undefined);
+    assert.strictEqual(result.imagesOmitted, undefined);
+  });
+});

--- a/test/read/read.test.ts
+++ b/test/read/read.test.ts
@@ -113,7 +113,8 @@ describe('read', () => {
     const result = await read(baseUrl, { skipSsrf: true });
     assert.ok(result);
     assert.ok(result.cost.tokens > 0);
-    assert.equal(result.cost.tokens, Math.ceil(result.content.length / 4));
+    // cost.tokens now measures the whole serialized envelope, not just content.
+    assert.equal(result.cost.tokens, Math.ceil(JSON.stringify(result).length / 4));
   });
 
   it('returns null for non-200 status', async () => {

--- a/test/replay/engine.test.ts
+++ b/test/replay/engine.test.ts
@@ -16,7 +16,11 @@ describe('replayEndpoint', () => {
 
   before(async () => {
     server = createServer((req, res) => {
-      if (req.url?.startsWith('/api/items')) {
+      if (req.url === '/api/items-large') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        const items = Array.from({ length: 500 }, (_, i) => ({ id: i, name: `Widget ${i}`.repeat(10) }));
+        res.end(JSON.stringify(items));
+      } else if (req.url?.startsWith('/api/items')) {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify([{ id: 1, name: 'Widget' }, { id: 2, name: 'Gadget' }]));
       } else if (req.url === '/api/item/42') {
@@ -163,6 +167,29 @@ describe('replayEndpoint', () => {
     const result = await replayEndpoint(skill, 'get-api-item', { _skipSsrfCheck: true });
     assert.equal(result.status, 200);
     assert.deepEqual(result.data, { id: 42, name: 'Special' });
+  });
+
+  it('returns structured truncation metadata when maxBytes cuts the response', async () => {
+    const skill = makeSkill();
+    skill.endpoints.push({
+      id: 'get-api-items-large',
+      method: 'GET',
+      path: '/api/items-large',
+      queryParams: {},
+      headers: {},
+      responseShape: { type: 'array', fields: ['id', 'name'] },
+      examples: {
+        request: { url: `${baseUrl}/api/items-large`, headers: {} },
+        responsePreview: [],
+      },
+    });
+
+    const result = await replayEndpoint(skill, 'get-api-items-large', { maxBytes: 500, _skipSsrfCheck: true });
+    assert.equal(result.status, 200);
+    assert.ok(result.truncated, 'expected truncated to be present');
+    assert.notStrictEqual(result.truncated, true, 'must be TruncationInfo, not boolean');
+    const info = result.truncated as { originalBytes: number; droppedItems: number };
+    assert.ok(info.originalBytes > 0);
   });
 });
 

--- a/test/replay/truncate.test.ts
+++ b/test/replay/truncate.test.ts
@@ -224,7 +224,7 @@ describe('recursive truncation (spec 2026-07-19)', () => {
     assert.strictEqual(info.droppedItems, data.length - 1);
   });
 
-  it('recomputes honest keptItems for the schema-sample fallback (object input)', () => {
+  it('recomputes honest keptItems for the schema-sample fallback (object input, no nested array)', () => {
     const wide: Record<string, string> = {};
     for (let i = 0; i < 500; i++) wide[`field${i}`] = `value-${i}`;
     const result = truncateResponse(wide, { maxBytes: 20 });
@@ -233,5 +233,24 @@ describe('recursive truncation (spec 2026-07-19)', () => {
     if (info.note?.includes('schema sample returned')) {
       assert.strictEqual(info.keptItems, 0);
     }
+  });
+
+  it('recomputes honest keptItems for the schema-sample fallback (object-topped input, nested array survives)', () => {
+    // Object-topped response (polymarket shape) whose nested array is what
+    // actually gets sampled down to 1 element — keptItems must reflect that
+    // surviving element, not "0" just because the top level isn't an array.
+    const wideItem: Record<string, string> = {};
+    for (let i = 0; i < 200; i++) wideItem[`field${i}`] = `v${i}`;
+    const data = {
+      $schema: 'https://example.com/schema.json',
+      data: Array.from({ length: 50 }, () => ({ ...wideItem })),
+    };
+    const result = truncateResponse(data, { maxBytes: 50 });
+    assert.ok(result.truncated !== false);
+    const info = result.truncated as { note?: string; keptItems: number };
+    assert.ok(info.note?.includes('schema sample returned'));
+    const out = result.data as { data: unknown[] };
+    assert.strictEqual(out.data.length, 1);
+    assert.strictEqual(info.keptItems, 1);
   });
 });

--- a/test/replay/truncate.test.ts
+++ b/test/replay/truncate.test.ts
@@ -32,7 +32,7 @@ describe('truncateResponse', () => {
       assert.ok(Buffer.byteLength(serialized) > 50_000, 'test data should exceed 50KB');
 
       const result = truncateResponse(items, { maxBytes: 50_000 });
-      assert.strictEqual(result.truncated, true);
+      assert.ok(result.truncated !== false);
 
       const truncatedBytes = Buffer.byteLength(JSON.stringify(result.data));
       assert.ok(truncatedBytes <= 50_000, `should be under 50KB, got ${truncatedBytes}`);
@@ -49,7 +49,7 @@ describe('truncateResponse', () => {
       }];
 
       const result = truncateResponse(items, { maxBytes: 50_000 });
-      assert.strictEqual(result.truncated, true);
+      assert.ok(result.truncated !== false);
 
       const truncatedBytes = Buffer.byteLength(JSON.stringify(result.data));
       assert.ok(truncatedBytes <= 50_000, `should be under 50KB, got ${truncatedBytes}`);
@@ -71,7 +71,7 @@ describe('truncateResponse', () => {
       };
 
       const result = truncateResponse(data, { maxBytes: 50_000 });
-      assert.strictEqual(result.truncated, true);
+      assert.ok(result.truncated !== false);
 
       const truncatedBytes = Buffer.byteLength(JSON.stringify(result.data));
       assert.ok(truncatedBytes <= 50_000, `should be under 50KB, got ${truncatedBytes}`);
@@ -101,7 +101,7 @@ describe('truncateResponse', () => {
     it('uses 50KB default when no maxBytes specified', () => {
       const data = { body: 'x'.repeat(60_000) };
       const result = truncateResponse(data);
-      assert.strictEqual(result.truncated, true);
+      assert.ok(result.truncated !== false);
     });
 
     it('does not truncate small data with default maxBytes', () => {
@@ -127,7 +127,7 @@ describe('truncateResponse', () => {
     it('handles string data over limit', () => {
       const data = 'x'.repeat(100_000);
       const result = truncateResponse(data, { maxBytes: 1_000 });
-      assert.strictEqual(result.truncated, true);
+      assert.ok(result.truncated !== false);
       assert.ok((result.data as string).endsWith('... [truncated]'));
       assert.ok(Buffer.byteLength(JSON.stringify(result.data)) <= 1_000);
     });
@@ -137,5 +137,71 @@ describe('truncateResponse', () => {
       assert.strictEqual(result.data, 42);
       assert.strictEqual(result.truncated, false);
     });
+  });
+});
+
+describe('recursive truncation (spec 2026-07-19)', () => {
+  it('bounds a wrapper object with a huge nested array (polymarket shape)', () => {
+    const big = Array.from({ length: 5000 }, (_, i) => ({
+      id: String(i),
+      title: 'Event ' + i,
+      description: 'x'.repeat(50),
+    }));
+    const data = { $schema: 'https://example.com/schema.json', data: big };
+    const result = truncateResponse(data, { maxBytes: 4000 });
+    const outBytes = Buffer.byteLength(JSON.stringify(result.data), 'utf-8');
+    assert.ok(outBytes <= 8000, `expected <= 8000 bytes, got ${outBytes}`);
+    assert.ok(result.truncated !== false);
+    const info = result.truncated as { originalBytes: number; finalBytes: number; droppedItems: number; keptItems: number };
+    assert.ok(info.droppedItems > 0);
+    assert.ok(info.keptItems >= 1);
+    assert.ok(info.originalBytes > info.finalBytes);
+    const out = result.data as { $schema: string; data: unknown[] };
+    assert.strictEqual(out.$schema, 'https://example.com/schema.json'); // small scalars survive
+    assert.ok(out.data.length >= 1); // never emptied
+  });
+
+  it('recurses into GraphQL-style nesting', () => {
+    const edges = Array.from({ length: 1000 }, (_, i) => ({ node: { id: i, body: 'y'.repeat(100) } }));
+    const data = { data: { search: { edges, pageInfo: { hasNext: true } } } };
+    const result = truncateResponse(data, { maxBytes: 3000 });
+    const outBytes = Buffer.byteLength(JSON.stringify(result.data), 'utf-8');
+    assert.ok(outBytes <= 6000, `expected <= 6000 bytes, got ${outBytes}`);
+    assert.ok(result.truncated !== false);
+    const out = result.data as { data: { search: { edges: unknown[]; pageInfo: { hasNext: boolean } } } };
+    assert.ok(out.data.search.edges.length >= 1);
+    assert.strictEqual(out.data.search.pageInfo.hasNext, true);
+  });
+
+  it('never returns an empty array for non-empty input (single oversized item)', () => {
+    const data = [{ id: 1, content: 'z'.repeat(10_000) }];
+    const result = truncateResponse(data, { maxBytes: 2000 });
+    const out = result.data as Array<Record<string, unknown>>;
+    assert.strictEqual(out.length, 1);
+    assert.ok((out[0].content as string).length < 10_000);
+    assert.strictEqual(out[0].id, 1);
+    assert.ok(result.truncated !== false);
+    assert.ok((result.truncated as { note?: string }).note);
+  });
+
+  it('distinguishes truly-empty from truncated-to-sample', () => {
+    const result = truncateResponse([], { maxBytes: 100 });
+    assert.deepStrictEqual(result.data, []);
+    assert.strictEqual(result.truncated, false);
+  });
+
+  it('caps recursion depth without throwing', () => {
+    let deep: Record<string, unknown> = { leaf: 'v'.repeat(2000) };
+    for (let i = 0; i < 50; i++) deep = { child: deep, pad: 'p'.repeat(200) };
+    const result = truncateResponse(deep, { maxBytes: 1000 });
+    assert.ok(result.truncated !== false);
+    assert.ok(JSON.stringify(result.data).includes('[truncated'));
+  });
+
+  it('treats maxBytes <= 0 or non-finite as default', () => {
+    const small = { a: 1 };
+    assert.strictEqual(truncateResponse(small, { maxBytes: 0 }).truncated, false);
+    assert.strictEqual(truncateResponse(small, { maxBytes: -5 }).truncated, false);
+    assert.strictEqual(truncateResponse(small, { maxBytes: Number.NaN }).truncated, false);
   });
 });

--- a/test/replay/truncate.test.ts
+++ b/test/replay/truncate.test.ts
@@ -204,4 +204,34 @@ describe('recursive truncation (spec 2026-07-19)', () => {
     assert.strictEqual(truncateResponse(small, { maxBytes: -5 }).truncated, false);
     assert.strictEqual(truncateResponse(small, { maxBytes: Number.NaN }).truncated, false);
   });
+
+  it('recomputes honest stats for the schema-sample fallback (array input)', () => {
+    // Wide-flat object per element: many small scalar fields the walk cannot
+    // shrink (not strings over cap, not nested objects/arrays), so the
+    // array-pop loop still leaves the result more than 2x over budget and
+    // the schema-sample safety net kicks in.
+    const wideItem: Record<string, string> = {};
+    for (let i = 0; i < 200; i++) wideItem[`field${i}`] = `v${i}`;
+    const data = Array.from({ length: 50 }, () => ({ ...wideItem }));
+    const result = truncateResponse(data, { maxBytes: 50 });
+    assert.ok(result.truncated !== false);
+    const info = result.truncated as { note?: string; droppedItems: number; keptItems: number };
+    assert.ok(info.note?.includes('schema sample returned'));
+    // Sample caps arrays to a single element.
+    const out = result.data as unknown[];
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(info.keptItems, 1);
+    assert.strictEqual(info.droppedItems, data.length - 1);
+  });
+
+  it('recomputes honest keptItems for the schema-sample fallback (object input)', () => {
+    const wide: Record<string, string> = {};
+    for (let i = 0; i < 500; i++) wide[`field${i}`] = `value-${i}`;
+    const result = truncateResponse(wide, { maxBytes: 20 });
+    assert.ok(result.truncated !== false);
+    const info = result.truncated as { note?: string; keptItems: number };
+    if (info.note?.includes('schema sample returned')) {
+      assert.strictEqual(info.keptItems, 0);
+    }
+  });
 });


### PR DESCRIPTION
## Problem

Token economy is ApiTap's headline claim, and both output paths violated it (found dogfooding v1.13.0):

- **`maxBytes` was ignored for nested payloads.** `truncateResponse` only truncated top-level string fields of objects, so a wrapper shape like `{$schema, data: [...]}` (gamma-api.polymarket.com `/events`) returned **301 KB against `maxBytes: 4000`** — while stamped `truncated: true`. GraphQL shapes hit the same wall.
- **Truncate-to-empty was indistinguishable from empty.** A single array item over budget yielded `data: [], truncated: true` — an agent can't tell "API returned nothing" from "everything was dropped."
- **The `read` envelope leaked unbounded metadata.** `links`/`images` bypassed `maxBytes` entirely (responsive-crop image URLs duplicated 2-3×), and `cost.tokens` counted only `content` — claiming ~3,750 tokens for envelopes several times that.

## What changed

```mermaid
flowchart LR
    subgraph replay["Replay path"]
        A[fetch response] --> T["truncateResponse<br/>(recursive budget walk)"]
        T --> M["TruncationInfo<br/>{originalBytes, finalBytes,<br/>droppedItems, keptItems, note}"]
        M --> E[engine / batch / browse / MCP / CLI]
    end
    subgraph readp["Read path (generic HTML only)"]
        R[extractContent] --> D["envelope diet<br/>links: dedupe+cap 100<br/>images: opt-in, cap 50"]
        D --> C["cost.tokens over<br/>whole envelope"]
    end
    style T fill:#2d6a4f,color:#fff
    style D fill:#2d6a4f,color:#fff
    style M fill:#40516f,color:#fff
```

- **`src/replay/truncate.ts` rewritten**: budget-spending recursion into whichever fields dominate serialized size; drops array items at any depth; never returns an empty container for non-empty input (worst case: one shape-sample item with capped strings); depth cap 32; schema-sample fallback past 2×budget.
- **`truncated: boolean` → `TruncationInfo` object** (truthy-compatible; `if (result.truncated)` keeps working — strict `=== true` checks are the one BREAKING surface, see CHANGELOG). Propagated through engine, batch, browse, MCP, and CLI (`--json` plus a new human-readable summary line: `truncated: kept 1 items, dropped 40, 4331 KB → 7 KB`).
- **Read envelope diet** (generic pipeline only; `scan: false` legacy envelope byte-identical): links deduped by href, capped at 100 with `linksOmitted`; images off by default, restored via `includeImages` / `--images` (deduped by URL-sans-query, cap 50, `imagesOmitted`); `cost.tokens` measured over the whole envelope; `maxBytes` shrinks links before content.
- Hermetic MCP test via the existing internal `_skipSsrfCheck` server option now forwarded to `read()` — **not** exposed in any tool schema; production forwards `undefined` so SSRF validation is unchanged.

## Verification

- 1,621 tests passing (20 new), typecheck clean, TDD throughout.
- Live repro of both original bugs: polymarket `/events` with `maxBytes: 4000` now returns 6,826 bytes with honest metadata; techcrunch WP posts return a shape sample instead of `[]`.
- Reviews: per-task spec+quality reviews, whole-branch review, independent security pass — no Critical findings; SSRF bypass confirmed unreachable from MCP clients and CLI tool surface.

Follow-up issues (triaged non-blocking, filed separately): wide-flat-object bound in schemaSample, O(n²) array pop loop, envelope content re-shrink after links exhausted, deepwiki decoder safeFetch routing, `_skipSsrfCheck` env hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGCuodgupuMcrGs4dWA67e
