### PR TITLE
Issue batch: truncation bounds (#60, #61), envelope re-slice (#62), SSRF-consistency (#63, #64)

### DIFF
--- a/src/capture/verifier.ts
+++ b/src/capture/verifier.ts
@@ -1,6 +1,6 @@
 // src/capture/verifier.ts
 import type { SkillFile, SkillEndpoint, Replayability } from '../types.js';
-import { resolveAndValidateUrl } from '../skill/ssrf.js';
+import { resolveAndValidateUrl, assertSsrfBypassAllowed } from '../skill/ssrf.js';
 
 /**
  * Heuristic tier classification for non-GET endpoints (or when verification is skipped).
@@ -177,6 +177,7 @@ export interface VerifyOptions {
  * Returns a new skill file with replayability tags on all endpoints.
  */
 export async function verifyEndpoints(skill: SkillFile, opts?: VerifyOptions): Promise<SkillFile> {
+  assertSsrfBypassAllowed(opts?._skipSsrfCheck);
   const verifiedEndpoints = await Promise.all(
     skill.endpoints.map(async (ep) => {
       let replayability: Replayability;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -494,6 +494,7 @@ async function handleReplay(positional: string[], flags: Record<string, string |
   const dangerDisableSsrf = flags['danger-disable-ssrf'] === true;
   if (dangerDisableSsrf) {
     console.error('[apitap] WARNING: SSRF protection is disabled via --danger-disable-ssrf');
+    process.env.APITAP_DANGER_DISABLE_SSRF = '1'; // acknowledged operator override (see assertSsrfBypassAllowed)
   }
 
   let egressCheckOverride: false | 'annotate' | 'block' | undefined = undefined;
@@ -1947,6 +1948,7 @@ async function handleServe(positional: string[], flags: Record<string, string | 
 async function handleMcp(flags: Record<string, string | boolean>): Promise<void> {
   if (flags['danger-disable-ssrf'] === true) {
     console.error('[apitap] WARNING: SSRF protection is disabled via --danger-disable-ssrf');
+    process.env.APITAP_DANGER_DISABLE_SSRF = '1'; // acknowledged operator override (see assertSsrfBypassAllowed)
   }
   const server = createMcpServer({
     skillsDir: SKILLS_DIR,
@@ -2214,6 +2216,10 @@ async function handleBrowse(positional: string[], flags: Record<string, string |
   const { browse } = await import('./orchestration/browse.js');
   const { SessionCache } = await import('./orchestration/cache.js');
 
+  if (flags['danger-disable-ssrf'] === true) {
+    console.error('[apitap] WARNING: SSRF protection is disabled via --danger-disable-ssrf');
+    process.env.APITAP_DANGER_DISABLE_SSRF = '1'; // acknowledged operator override (see assertSsrfBypassAllowed)
+  }
   const result = await browse(fullUrl, {
     skillsDir: SKILLS_DIR,
     cache: new SessionCache(),

--- a/src/discovery/fetch.ts
+++ b/src/discovery/fetch.ts
@@ -13,6 +13,9 @@ export interface SafeFetchOptions {
   method?: 'GET' | 'HEAD';
   maxBodySize?: number;
   skipSsrf?: boolean; // bypass SSRF check (for testing with local servers)
+  /** Extra request headers, merged over the defaults (issue #63: lets
+   *  decoders route trick-header requests through safeFetch). */
+  headers?: Record<string, string>;
 }
 
 const DEFAULT_TIMEOUT = 5000;
@@ -47,6 +50,7 @@ export async function safeFetch(
       headers: {
         'User-Agent': USER_AGENT,
         'Accept': 'text/html,application/json,*/*',
+        ...options.headers,
       },
       redirect: 'manual',
     });

--- a/src/orchestration/browse.ts
+++ b/src/orchestration/browse.ts
@@ -4,6 +4,7 @@ import { readSkillFile } from '../skill/store.js';
 import { replayEndpoint } from '../replay/engine.js';
 import { SessionCache } from './cache.js';
 import { read } from '../read/index.js';
+import { assertSsrfBypassAllowed } from '../skill/ssrf.js';
 import { bridgeAvailable, requestBridgeCapture, DEFAULT_SOCKET } from '../bridge/client.js';
 import { signSkillFile } from '../skill/signing.js';
 import { deriveSigningKey } from '../auth/crypto.js';
@@ -162,6 +163,7 @@ export async function browse(
   url: string,
   options: BrowseOptions = {},
 ): Promise<BrowseResult> {
+  assertSsrfBypassAllowed(options._skipSsrfCheck);
   const { cache, skillsDir, task, skipDiscovery, maxBytes = 50_000 } = options;
   const fullUrl = url.startsWith('http') ? url : `https://${url}`;
 

--- a/src/read/decoders/deepwiki.ts
+++ b/src/read/decoders/deepwiki.ts
@@ -1,6 +1,7 @@
 // src/read/decoders/deepwiki.ts
 import type { Decoder, ReadResult } from '../types.js';
-import { validateUrl } from '../../skill/ssrf.js';
+import { assertSsrfBypassAllowed } from '../../skill/ssrf.js';
+import { safeFetch } from '../../discovery/fetch.js';
 
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
@@ -36,31 +37,40 @@ export const deepwikiDecoder: Decoder = {
     const repo = match[3];
     const pagePath = match[4] || '';
 
-    // SSRF check
-    const ssrfResult = validateUrl(url);
-    if (!ssrfResult.safe) return null;
-
     // Sanitize extracted values for header injection
     const sanitize = (s: string) => s.replace(/[\r\n]/g, '');
 
     // Construct the path for the RSC request
     const fullPath = sanitize(`/${org}/${repo}${pagePath}`);
 
+    // Test-only base-URL override so hermetic tests can point the decoder
+    // at a local server (host is otherwise pinned to deepwiki.com). Gated
+    // to test contexts like every other SSRF-relevant escape hatch (#64).
+    assertSsrfBypassAllowed(options._testBaseUrl);
+    const fetchUrl = options._testBaseUrl
+      ? url.replace(/^https?:\/\/(www\.)?deepwiki\.com/, options._testBaseUrl)
+      : url;
+
     try {
-      const response = await fetch(url, {
+      // safeFetch: SSRF validation with DNS resolution, manual single-hop
+      // redirects with target re-validation, timeout, and body cap — the
+      // same pipeline every other decoder path gets (issue #63).
+      const response = await safeFetch(fetchUrl, {
+        skipSsrf: options.skipSsrf,
+        timeout: 10_000,
+        maxBodySize: 2 * 1024 * 1024,
         headers: {
           'RSC': '1',
           'Next-Url': fullPath,
           'User-Agent': 'Mozilla/5.0 (compatible; ApiTap/1.0)',
         },
-        signal: AbortSignal.timeout(10_000),
       });
 
-      if (!response.ok) {
+      if (!response || response.status < 200 || response.status >= 300) {
         return null;
       }
 
-      const rscPayload = await response.text();
+      const rscPayload = response.body;
 
       // Extract markdown content from RSC text nodes
       // Format: {id}:T{hexLength},{content}

--- a/src/read/index.ts
+++ b/src/read/index.ts
@@ -13,9 +13,10 @@ import { assertSsrfBypassAllowed } from '../skill/ssrf.js';
 
 export interface ReadOptions {
   skipSsrf?: boolean;
-  /** Approximate envelope size bound: content is sliced to this many chars
-   *  and links shrink to fit, but content + fixed metadata keep priority and
-   *  can exceed it. */
+  /** Envelope size bound: links shrink first, then content is re-sliced
+   *  byte-accurately (with a contentTruncated signal) until the serialized
+   *  envelope fits. Only fixed metadata — including scanner findings —
+   *  larger than the budget itself can still exceed it. */
   maxBytes?: number;
   /** Enable trap-aware content scanning on fetched HTML. Default: true.
    *  When false, the scanner does not run and the ReadResult has no

--- a/src/read/index.ts
+++ b/src/read/index.ts
@@ -9,6 +9,7 @@ import { findDecoder } from './decoders/index.js';
 import { parseHead, extractContent } from './extract.js';
 import { scanRawHtml } from './scan.js';
 import { appendFinding } from '../trapaware/audit.js';
+import { assertSsrfBypassAllowed } from '../skill/ssrf.js';
 
 export interface ReadOptions {
   skipSsrf?: boolean;
@@ -67,6 +68,7 @@ function dietImages(images: Array<{ alt: string; src: string }>): Array<{ alt: s
  * same content-injection attack surface.
  */
 export async function read(url: string, options: ReadOptions = {}): Promise<ReadResult | null> {
+  assertSsrfBypassAllowed(options.skipSsrf);
   const scanEnabled = options.scan !== false;
 
   // Try site-specific decoder first

--- a/src/read/index.ts
+++ b/src/read/index.ts
@@ -77,6 +77,7 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
       if (options.maxBytes && result.content.length > options.maxBytes) {
         result.content = result.content.slice(0, options.maxBytes);
         result.cost.tokens = Math.ceil(result.content.length / 4);
+        result.contentTruncated = true;
       }
       // Decoders bypass scanning — they extract from structured sources.
       // Do NOT attach a findings field; preserve existing decoder envelope.
@@ -115,8 +116,10 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
   }
 
   let content = body.content;
+  let contentTruncated = false;
   if (options.maxBytes && content.length > options.maxBytes) {
     content = content.slice(0, options.maxBytes);
+    contentTruncated = true;
   }
 
   const title = head.ogTitle || head.title || null;
@@ -160,6 +163,7 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
     ...(linksOmitted > 0 ? { linksOmitted } : {}),
     images,
     ...(imagesOmitted > 0 ? { imagesOmitted } : {}),
+    ...(contentTruncated ? { contentTruncated: true } : {}),
     metadata: {
       type: head.ogType || 'unknown',
       publishedAt: head.publishedTime || null,
@@ -173,6 +177,10 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
 
   // maxBytes bounds the envelope: shrink links (halving) before touching content.
   if (options.maxBytes) {
+    // cost.tokens is recomputed after shrinking; measure with its widest
+    // possible value so the final number never grows the envelope past
+    // the budget we just enforced.
+    envelope.cost.tokens = Math.ceil(options.maxBytes / 4);
     while (
       Buffer.byteLength(JSON.stringify(envelope), 'utf-8') > options.maxBytes &&
       envelope.links.length > 0
@@ -180,6 +188,32 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
       const keep = Math.floor(envelope.links.length / 2);
       envelope.linksOmitted = (envelope.linksOmitted ?? 0) + (envelope.links.length - keep);
       envelope.links = envelope.links.slice(0, keep);
+    }
+
+    // Links exhausted but still over budget: binary-search the largest
+    // content prefix whose full envelope fits (issue #62). Byte-accurate —
+    // measured against the serialized envelope, not content length. Only
+    // fixed metadata larger than maxBytes itself can still overshoot.
+    if (
+      Buffer.byteLength(JSON.stringify(envelope), 'utf-8') > options.maxBytes &&
+      envelope.content.length > 0
+    ) {
+      const full = envelope.content;
+      const suffix = '... [truncated]';
+      // Set the signal BEFORE measuring so its own bytes are budgeted.
+      envelope.contentTruncated = true;
+      let lo = 0;
+      let hi = full.length;
+      while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        envelope.content = full.slice(0, mid) + suffix;
+        if (Buffer.byteLength(JSON.stringify(envelope), 'utf-8') <= options.maxBytes) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      envelope.content = full.slice(0, lo) + suffix;
     }
   }
 

--- a/src/read/peek.ts
+++ b/src/read/peek.ts
@@ -1,6 +1,7 @@
 // src/read/peek.ts
 import type { PeekResult } from './types.js';
 import { safeFetch } from '../discovery/fetch.js';
+import { assertSsrfBypassAllowed } from '../skill/ssrf.js';
 
 export interface PeekOptions {
   skipSsrf?: boolean;
@@ -11,6 +12,7 @@ export interface PeekOptions {
  * Falls back to GET if HEAD fails.
  */
 export async function peek(url: string, options: PeekOptions = {}): Promise<PeekResult> {
+  assertSsrfBypassAllowed(options.skipSsrf);
   const signals: string[] = [];
 
   // Try HEAD first

--- a/src/read/types.ts
+++ b/src/read/types.ts
@@ -25,6 +25,8 @@ export interface ReadResult {
   linksOmitted?: number;
   /** Number of images dropped (all of them unless includeImages). Absent on the legacy path. */
   imagesOmitted?: number;
+  /** True when content was cut to fit maxBytes. Absent on the legacy path. */
+  contentTruncated?: boolean;
   metadata: {
     type: string;
     publishedAt: string | null;

--- a/src/replay/engine.ts
+++ b/src/replay/engine.ts
@@ -5,7 +5,7 @@ import { substituteBodyVariables } from '../capture/body-variables.js';
 import { parseJwtClaims } from '../capture/entropy.js';
 import { refreshTokens } from '../auth/refresh.js';
 import { truncateResponse, type TruncationInfo } from './truncate.js';
-import { resolveAndValidateUrl } from '../skill/ssrf.js';
+import { resolveAndValidateUrl, assertSsrfBypassAllowed } from '../skill/ssrf.js';
 import { snapshotSchema } from '../contract/schema.js';
 import { diffSchema, type ContractWarning } from '../contract/diff.js';
 import { scanOutboundRequest } from './egress.js';
@@ -310,6 +310,7 @@ export async function replayEndpoint(
 ): Promise<ReplayResult> {
   // Normalize options: support both new ReplayOptions and legacy params-only
   const options = normalizeOptions(optionsOrParams);
+  assertSsrfBypassAllowed(options._skipSsrfCheck);
   const { params = {}, authManager, domain } = options;
 
   const endpoint = skill.endpoints.find(e => e.id === endpointId);

--- a/src/replay/truncate.ts
+++ b/src/replay/truncate.ts
@@ -12,6 +12,8 @@ export interface TruncationInfo {
   droppedItems: number;
   /** Items surviving in the largest truncated array. */
   keptItems: number;
+  /** Object fields cut by the schema-sample fallback (wide flat objects). */
+  droppedFields?: number;
   note?: string;
 }
 
@@ -61,18 +63,47 @@ function maxArrayLength(value: unknown): number {
   return 0;
 }
 
-/** Aggressive last-resort shape sample: structure survives, bulk does not. */
-function schemaSample(value: unknown, depth: number): unknown {
+/** Floor for the sample budget: tiny maxBytes still yields usable structure. */
+const MIN_SAMPLE_BUDGET = 2_048;
+
+interface SampleStats {
+  /** Approximate bytes emitted so far, charged across the whole recursion. */
+  spent: number;
+  /** Object fields dropped once the budget was exhausted (issue #60). */
+  droppedFields: number;
+}
+
+/**
+ * Aggressive last-resort shape sample: structure survives, bulk does not.
+ * Spends a shared byte budget as it walks; once exhausted, remaining object
+ * fields are dropped and counted — a wide flat object of small scalars no
+ * longer escapes the size bound (issue #60).
+ */
+function schemaSample(value: unknown, depth: number, budget: number, sstats: SampleStats): unknown {
   if (depth > MAX_DEPTH) return '[truncated: depth]';
-  if (typeof value === 'string') return value.length > 100 ? value.slice(0, 100) + '... [truncated]' : value;
-  if (value === null || typeof value !== 'object') return value;
+  if (typeof value === 'string') {
+    const s = value.length > 100 ? value.slice(0, 100) + '... [truncated]' : value;
+    sstats.spent += byteLength(JSON.stringify(s));
+    return s;
+  }
+  if (value === null || typeof value !== 'object') {
+    sstats.spent += size(value);
+    return value;
+  }
   if (Array.isArray(value)) {
-    return value.length === 0 ? [] : [schemaSample(value[0], depth + 1)];
+    sstats.spent += 2;
+    return value.length === 0 ? [] : [schemaSample(value[0], depth + 1, budget, sstats)];
   }
+  const entries = Object.entries(value as Record<string, unknown>);
   const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-    out[k] = schemaSample(v, depth + 1);
+  let kept = 0;
+  for (const [k, v] of entries) {
+    if (sstats.spent >= budget) break;
+    sstats.spent += byteLength(JSON.stringify(k)) + 2; // key + ':' + ','
+    out[k] = schemaSample(v, depth + 1, budget, sstats);
+    kept++;
   }
+  sstats.droppedFields += entries.length - kept;
   return out;
 }
 
@@ -80,7 +111,8 @@ function truncateValue(value: unknown, budget: number, depth: number, stats: Wal
   if (typeof value === 'string') return capString(value);
   if (value === null || typeof value !== 'object') return value;
   if (depth > MAX_DEPTH) return '[truncated: depth]';
-  if (size(value) <= budget) return value;
+  const totalSize = size(value);
+  if (totalSize <= budget) return value;
 
   if (Array.isArray(value)) {
     // Largest prefix (>= 1 item) fitting the budget. Serialize each item
@@ -107,19 +139,27 @@ function truncateValue(value: unknown, budget: number, depth: number, stats: Wal
 
   // Object: recurse into dominant fields, largest first. Small scalar
   // fields are never dropped — they are the schema the agent needs.
+  // Size is tracked incrementally by replacement delta: re-serializing the
+  // whole result per field made wide objects quadratic (see issue #61's
+  // array twin; same failure mode).
   const record = value as Record<string, unknown>;
   const result: Record<string, unknown> = { ...record };
   const fields = Object.entries(record)
     .map(([k, v]) => ({ k, v, s: size(v) }))
     .sort((a, b) => b.s - a.s);
+  let currentSize = totalSize;
   for (const field of fields) {
-    if (size(result) <= budget) break;
+    if (currentSize <= budget) break;
     if (typeof field.v === 'string') {
-      result[field.k] = capString(field.v);
+      const capped = capString(field.v);
+      result[field.k] = capped;
+      currentSize += size(capped) - field.s;
     } else if (field.v !== null && typeof field.v === 'object') {
-      const others = size(result) - field.s;
+      const others = currentSize - field.s;
       const fieldBudget = Math.max(budget - others, MIN_FIELD_BUDGET);
-      result[field.k] = truncateValue(field.v, fieldBudget, depth + 1, stats);
+      const shrunk = truncateValue(field.v, fieldBudget, depth + 1, stats);
+      result[field.k] = shrunk;
+      currentSize += size(shrunk) - field.s;
     }
     // numbers/booleans/null: nothing to shrink
   }
@@ -135,9 +175,9 @@ function truncateValue(value: unknown, budget: number, depth: number, stats: Wal
  * worst case the caller gets one shape-sample item with capped strings.
  *
  * The result may overshoot maxBytes by per-level overhead; if it exceeds
- * 2 x maxBytes a schema-sample fallback replaces it. The fallback keeps
- * every key of a flat object, so a very wide object of small scalars can
- * still exceed the bound. Exact byte fitting is not a goal — honesty and
+ * 2 x maxBytes a schema-sample fallback replaces it, spending a byte budget
+ * of max(maxBytes, 2 KB) and dropping (and counting) object fields once it
+ * is exhausted. Exact byte fitting is not a goal — honesty and
  * order-of-magnitude correctness are.
  */
 export function truncateResponse(data: unknown, options?: TruncateOptions): TruncateResult {
@@ -194,9 +234,14 @@ export function truncateResponse(data: unknown, options?: TruncateOptions): Trun
   let result = truncateValue(data, maxBytes, 0, stats);
 
   // Safety net: bounded overshoot guarantee.
+  let droppedFields = 0;
   if (size(result) > 2 * maxBytes) {
-    result = schemaSample(data, 0);
-    stats.note = 'response exceeded budget after truncation; schema sample returned';
+    const sstats: SampleStats = { spent: 0, droppedFields: 0 };
+    result = schemaSample(data, 0, Math.max(maxBytes, MIN_SAMPLE_BUDGET), sstats);
+    droppedFields = sstats.droppedFields;
+    stats.note =
+      'response exceeded budget after truncation; schema sample returned' +
+      (droppedFields > 0 ? `; ${droppedFields} fields dropped` : '');
     // The walk's dropped/kept counts describe the discarded truncateValue
     // attempt, not this sample — recompute honestly for the sample we
     // actually return. keptItems is the largest array surviving anywhere
@@ -216,6 +261,7 @@ export function truncateResponse(data: unknown, options?: TruncateOptions): Trun
       finalBytes: size(result),
       droppedItems: stats.droppedItems,
       keptItems: stats.keptItems,
+      ...(droppedFields > 0 ? { droppedFields } : {}),
       ...(stats.note ? { note: stats.note } : {}),
     },
   };

--- a/src/replay/truncate.ts
+++ b/src/replay/truncate.ts
@@ -83,11 +83,19 @@ function truncateValue(value: unknown, budget: number, depth: number, stats: Wal
   if (size(value) <= budget) return value;
 
   if (Array.isArray(value)) {
-    const arr = [...value];
-    while (arr.length > 1 && size(arr) > budget) {
-      arr.pop();
-      stats.droppedItems++;
+    // Largest prefix (>= 1 item) fitting the budget. Serialize each item
+    // once and walk the exact cost down — JSON.stringify of an array is
+    // '[' + items joined by ',' + ']', so prefix cost is computable without
+    // re-serializing per drop (issue #61: the old pop loop was O(n²)).
+    const itemSizes = value.map((item) => size(item));
+    let keep = value.length;
+    let cost = 2 + itemSizes.reduce((a, b) => a + b, 0) + Math.max(value.length - 1, 0);
+    while (keep > 1 && cost > budget) {
+      keep--;
+      cost -= itemSizes[keep] + 1; // dropped item + its comma
     }
+    const arr = value.slice(0, keep);
+    stats.droppedItems += value.length - keep;
     if (arr.length >= 1 && size(arr) > budget) {
       // Single item still over budget: recurse into it, never drop to [].
       arr[0] = truncateValue(arr[0], Math.max(budget - 2, MIN_FIELD_BUDGET), depth + 1, stats);

--- a/src/skill/ssrf.ts
+++ b/src/skill/ssrf.ts
@@ -21,8 +21,12 @@ export interface ValidationResult {
 export function assertSsrfBypassAllowed(flag: unknown): void {
   if (!flag) return;
   if (process.env.NODE_TEST_CONTEXT || process.env.NODE_ENV === 'test') return;
+  // Operator path: the CLI's --danger-disable-ssrf flag exports this after
+  // printing its warning. Deliberate and visible, unlike a silent option.
+  if (process.env.APITAP_DANGER_DISABLE_SSRF === '1') return;
   throw new Error(
-    'SSRF bypass (skipSsrf/_skipSsrfCheck) is test-only and refused outside a test run',
+    'SSRF bypass (skipSsrf/_skipSsrfCheck) is test-only and refused outside a test run ' +
+    '(use --danger-disable-ssrf for the warned operator override)',
   );
 }
 

--- a/src/skill/ssrf.ts
+++ b/src/skill/ssrf.ts
@@ -11,6 +11,21 @@ export interface ValidationResult {
   originalHost?: string;
 }
 
+/**
+ * Test-only escape-hatch guard (issue #64). The skipSsrf/_skipSsrfCheck
+ * options exist so hermetic tests can hit loopback servers; outside a test
+ * run they must be inert. Called at every public ingress that accepts the
+ * flag — internal redirect re-validation (which passes skipSsrf after its
+ * own check) is deliberately not routed through this.
+ */
+export function assertSsrfBypassAllowed(flag: unknown): void {
+  if (!flag) return;
+  if (process.env.NODE_TEST_CONTEXT || process.env.NODE_ENV === 'test') return;
+  throw new Error(
+    'SSRF bypass (skipSsrf/_skipSsrfCheck) is test-only and refused outside a test run',
+  );
+}
+
 const INTERNAL_HOSTNAMES = ['localhost'];
 const INTERNAL_SUFFIXES = ['.local', '.internal', '.localhost', '.corp', '.intranet', '.lan', '.test', '.invalid', '.example'];
 

--- a/test/read/decoders/deepwiki.test.ts
+++ b/test/read/decoders/deepwiki.test.ts
@@ -138,23 +138,49 @@ describe('deepwikiDecoder', () => {
   describe('RSC content extraction', () => {
     afterEach(teardownServer);
 
-    it('extracts markdown from RSC payload', async () => {
+    it('extracts markdown from RSC payload via safeFetch (issue #63)', async () => {
       const payload = makeRscPayload(overviewContent);
       await setupServer(payload);
 
-      // Monkey-patch the URL to use our test server
-      const decoder = deepwikiDecoder;
-      const url = `${baseUrl}/myorg/myrepo`;
-
-      // We need to test against deepwiki.com pattern, so test the decode logic directly
-      // by calling with a URL that matches but redirecting fetch
-      const result = await decoder.decode(
-        url.replace(baseUrl, 'https://deepwiki.com'),
+      const result = await deepwikiDecoder.decode(
+        'https://deepwiki.com/myorg/myrepo',
         { _testBaseUrl: baseUrl, skipSsrf: true }
       );
 
-      // This won't work because the decoder fetches the actual URL
-      // Instead, let's test the extraction logic
+      assert.ok(result, 'decoder should extract content from the local RSC server');
+      assert.ok(result.content.includes('MyProject is a tool'), 'main content extracted');
+      assert.equal(result.metadata.source, 'deepwiki-rsc');
+      // The RSC request went through the pipeline with the trick headers.
+      assert.equal(lastRequestHeaders['rsc'], '1');
+      assert.equal(lastRequestHeaders['next-url'], '/myorg/myrepo');
+    });
+
+    it('does not blindly follow redirects (issue #63: safeFetch semantics)', async () => {
+      // Raw fetch() auto-follows redirects with no re-validation; safeFetch
+      // follows one hop only after re-validating the target. A redirect to a
+      // private address must be refused even mid-flight.
+      await new Promise<void>((resolve) => {
+        server = createServer((req: IncomingMessage, res: ServerResponse) => {
+          if (req.url?.includes('redirected')) {
+            res.writeHead(200, { 'Content-Type': 'text/x-component' });
+            res.end(makeRscPayload('# Attacker content that must not surface'.padEnd(60, '.')));
+            return;
+          }
+          res.writeHead(302, { Location: 'http://169.254.169.254/latest/meta-data/' });
+          res.end();
+        });
+        server.listen(0, '127.0.0.1', () => {
+          const addr = server.address() as { port: number };
+          baseUrl = `http://127.0.0.1:${addr.port}`;
+          resolve();
+        });
+      });
+
+      const result = await deepwikiDecoder.decode(
+        'https://deepwiki.com/myorg/myrepo',
+        { _testBaseUrl: baseUrl, skipSsrf: true }
+      );
+      assert.equal(result, null, 'redirect to a private address must yield null');
     });
 
     it('sends RSC header in request', async () => {

--- a/test/read/envelope-diet.test.ts
+++ b/test/read/envelope-diet.test.ts
@@ -16,8 +16,13 @@ describe('read envelope diet', () => {
   let base: string;
 
   before(async () => {
-    server = createServer((_req, res) => {
+    server = createServer((req, res) => {
       res.writeHead(200, { 'content-type': 'text/html' });
+      if (req.url === '/big') {
+        // Large content, zero links: link shrinking cannot rescue the envelope.
+        res.end(`<!doctype html><html><head><title>Big</title></head><body><article><p>${'Long content. '.repeat(600)}</p></article></body></html>`);
+        return;
+      }
       res.end(pageWithNoise());
     });
     await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
@@ -62,6 +67,21 @@ describe('read envelope diet', () => {
     const bytes = Buffer.byteLength(JSON.stringify(result), 'utf-8');
     assert.ok(bytes <= 6000, `envelope ${bytes} bytes`);
     assert.ok(result.content.length > 0, 'content survives before links');
+  });
+
+  it('re-slices content byte-accurately after links are exhausted, with a signal (issue #62)', async () => {
+    const result = await read(`${base}/big`, { skipSsrf: true, maxBytes: 2000 });
+    assert.ok(result);
+    const bytes = Buffer.byteLength(JSON.stringify(result), 'utf-8');
+    assert.ok(bytes <= 2000, `envelope ${bytes} bytes exceeds maxBytes 2000`);
+    assert.strictEqual(result.contentTruncated, true, 'content truncation must carry a signal');
+    assert.ok(result.content.length > 0, 'some content must survive');
+  });
+
+  it('does not set contentTruncated when the envelope fits', async () => {
+    const result = await read(`${base}/big`, { skipSsrf: true, maxBytes: 100_000 });
+    assert.ok(result);
+    assert.strictEqual(result.contentTruncated, undefined);
   });
 
   it('scan:false keeps the legacy envelope (no diet)', async () => {

--- a/test/replay/truncate.test.ts
+++ b/test/replay/truncate.test.ts
@@ -41,6 +41,42 @@ describe('truncateResponse', () => {
       assert.ok((result.data as unknown[]).length > 0);
     });
 
+    it('keeps the maximal prefix that fits the budget', () => {
+      const items = Array.from({ length: 500 }, (_, i) => ({
+        id: i,
+        body: 'x'.repeat(200),
+      }));
+      const result = truncateResponse(items, { maxBytes: 20_000 });
+      assert.ok(result.truncated !== false);
+      const kept = result.data as Array<{ id: number }>;
+      // Survivors are the original prefix, in order.
+      kept.forEach((item, i) => assert.equal(item.id, i));
+      // Maximal: adding the next item would exceed the budget.
+      const onePlus = items.slice(0, kept.length + 1);
+      assert.ok(
+        Buffer.byteLength(JSON.stringify(onePlus)) > 20_000,
+        'prefix is not maximal — one more item still fits'
+      );
+      assert.equal(result.truncated.droppedItems, items.length - kept.length);
+      assert.equal(result.truncated.keptItems, kept.length);
+    });
+
+    it('truncates a 20k-item array in linear time (issue #61)', () => {
+      const items = Array.from({ length: 20_000 }, (_, i) => ({
+        id: i,
+        name: `item-${i}`,
+        price: i * 1.5,
+      }));
+      const start = performance.now();
+      const result = truncateResponse(items, { maxBytes: 50_000 });
+      const elapsed = performance.now() - start;
+      assert.ok(result.truncated !== false);
+      assert.ok(
+        elapsed < 1_500,
+        `truncation took ${Math.round(elapsed)}ms — pop-loop re-serialization is quadratic`
+      );
+    });
+
     it('truncates string fields when single item exceeds limit', () => {
       const items = [{
         id: 1,

--- a/test/replay/truncate.test.ts
+++ b/test/replay/truncate.test.ts
@@ -241,6 +241,32 @@ describe('recursive truncation (spec 2026-07-19)', () => {
     assert.strictEqual(truncateResponse(small, { maxBytes: Number.NaN }).truncated, false);
   });
 
+  it('bounds a wide flat scalar object and reports dropped fields (issue #60)', () => {
+    // Thousands of small scalar fields: nothing for truncateValue to shrink
+    // (no long strings, no nested containers), and the old schemaSample kept
+    // every key — so the ~2x maxBytes guarantee was violable for id-keyed
+    // maps / locale dictionaries.
+    const wide: Record<string, number> = {};
+    for (let i = 0; i < 5_000; i++) wide[`key-${i}`] = i;
+    const originalBytes = Buffer.byteLength(JSON.stringify(wide));
+    assert.ok(originalBytes > 50_000, 'test data should be much larger than budget');
+
+    const start = performance.now();
+    const result = truncateResponse(wide, { maxBytes: 5_000 });
+    const elapsed = performance.now() - start;
+
+    assert.ok(result.truncated !== false);
+    const finalBytes = Buffer.byteLength(JSON.stringify(result.data));
+    assert.ok(finalBytes <= 10_000, `final ${finalBytes} bytes exceeds 2x maxBytes (10000)`);
+    const info = result.truncated as { note?: string; droppedFields?: number };
+    assert.ok(
+      (info.droppedFields ?? 0) > 0,
+      'droppedFields should report the fields cut from the sample'
+    );
+    assert.ok(info.note?.includes('fields dropped'), `note should mention dropped fields, got: ${info.note}`);
+    assert.ok(elapsed < 1_500, `took ${Math.round(elapsed)}ms — wide-object walk should be linear`);
+  });
+
   it('recomputes honest stats for the schema-sample fallback (array input)', () => {
     // Wide-flat object per element: many small scalar fields the walk cannot
     // shrink (not strings over cap, not nested objects/arrays), so the

--- a/test/security/ssrf-bypass-guard.test.ts
+++ b/test/security/ssrf-bypass-guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { join } from 'node:path';
+
+// Issue #64: the _skipSsrfCheck / skipSsrf escape hatch exists for hermetic
+// tests against loopback servers. It must be inert outside a test run —
+// a production process setting it gets an error, not an SSRF bypass.
+describe('SSRF bypass test-only guard (issue #64)', () => {
+  const root = process.cwd();
+
+  it('refuses skipSsrf/_skipSsrfCheck outside a test context', () => {
+    const readUrl = pathToFileURL(join(root, 'src/read/index.ts')).href;
+    const engineUrl = pathToFileURL(join(root, 'src/replay/engine.ts')).href;
+    const script = `
+      const { read } = await import(${JSON.stringify(readUrl)});
+      const { replayEndpoint } = await import(${JSON.stringify(engineUrl)});
+      const results = [];
+      try {
+        await read('http://127.0.0.1:9/x', { skipSsrf: true });
+        results.push('read:no-throw');
+      } catch (e) {
+        results.push('read:' + (/test-only/.test(e.message) ? 'guarded' : 'other(' + e.message + ')'));
+      }
+      try {
+        await replayEndpoint({}, 'x', { _skipSsrfCheck: true });
+        results.push('replay:no-throw');
+      } catch (e) {
+        results.push('replay:' + (/test-only/.test(e.message) ? 'guarded' : 'other(' + e.message + ')'));
+      }
+      console.log('RESULT=' + results.join('|'));
+    `;
+    const env = { ...process.env };
+    delete env.NODE_TEST_CONTEXT;
+    delete env.NODE_ENV;
+    const out = execFileSync(
+      process.execPath,
+      ['--import', 'tsx', '--input-type=module', '-e', script],
+      { cwd: root, env, encoding: 'utf-8' },
+    );
+    const line = out.split('\n').find((l) => l.startsWith('RESULT='));
+    assert.strictEqual(line, 'RESULT=read:guarded|replay:guarded', `child said: ${out}`);
+  });
+
+  it('allows the bypass inside a test context (this very run)', async () => {
+    const { read } = await import('../../src/read/index.js');
+    // Unreachable port: fetch fails and read returns null — but the guard
+    // must not throw while the node:test runner env marker is present.
+    const result = await read('http://127.0.0.1:9/x', { skipSsrf: true });
+    assert.strictEqual(result, null);
+  });
+});

--- a/test/security/ssrf-bypass-guard.test.ts
+++ b/test/security/ssrf-bypass-guard.test.ts
@@ -43,6 +43,33 @@ describe('SSRF bypass test-only guard (issue #64)', () => {
     assert.strictEqual(line, 'RESULT=read:guarded|replay:guarded', `child said: ${out}`);
   });
 
+  it('allows the bypass when the CLI danger flag set its acknowledgment env', () => {
+    // --danger-disable-ssrf is a deliberate, warned, operator-facing flag;
+    // the CLI exports APITAP_DANGER_DISABLE_SSRF=1 after printing its
+    // warning, and the guard must honor that outside test contexts.
+    const engineUrl = pathToFileURL(join(root, 'src/replay/engine.ts')).href;
+    const script = `
+      const { replayEndpoint } = await import(${JSON.stringify(engineUrl)});
+      try {
+        await replayEndpoint({ domain: 'x', endpoints: [] }, 'x', { _skipSsrfCheck: true });
+        console.log('RESULT=no-throw');
+      } catch (e) {
+        console.log('RESULT=' + (/test-only/.test(e.message) ? 'guarded' : 'passed-guard'));
+      }
+    `;
+    const env = { ...process.env, APITAP_DANGER_DISABLE_SSRF: '1' };
+    delete env.NODE_TEST_CONTEXT;
+    delete env.NODE_ENV;
+    const out = execFileSync(
+      process.execPath,
+      ['--import', 'tsx', '--input-type=module', '-e', script],
+      { cwd: root, env, encoding: 'utf-8' },
+    );
+    const line = out.split('\n').find((l) => l.startsWith('RESULT='));
+    // "passed-guard" = guard let it through and the (fake) skill errored later.
+    assert.strictEqual(line, 'RESULT=passed-guard', `child said: ${out}`);
+  });
+
   it('allows the bypass inside a test context (this very run)', async () => {
     const { read } = await import('../../src/read/index.js');
     // Unreachable port: fetch fails and read returns null — but the guard


### PR DESCRIPTION
Clears the five follow-up issues filed from PR #59's reviews. TDD throughout — every fix has a test that failed first. 1630 tests green.

## Fixes

- **#61 — O(n²) array truncation**: the pop loop re-stringified the whole array per dropped item; a 50k-item response took **>120s** (worse than the issue estimated). Now serializes each item once and computes exact prefix cost: **~30ms**, identical maximal-prefix semantics.
- **#60 — wide flat scalar objects escaped the ~2x maxBytes bound**: schemaSample now spends a byte budget of `max(maxBytes, 2 KB)` and drops+counts fields once exhausted (`TruncationInfo.droppedFields` + note). Also fixed the object walk's quadratic re-serialization (the array twin of #61 — 5k scalar fields took ~2s before even reaching the fallback).
- **#62 — read envelope exceeded maxBytes after link exhaustion**: binary-search re-slice of content against the serialized envelope, with a `contentTruncated` signal (generic + decoder paths). The flag and the recomputed `cost.tokens` are budgeted *before* measurement so they can't push the envelope back over. Legacy (`scan: false`) envelope stays byte-identical.
- **#64 — `_skipSsrfCheck` constrained to test contexts**: `assertSsrfBypassAllowed()` refuses the bypass outside the node:test runner / `NODE_ENV=test`, guarded at every public ingress (`replayEndpoint`, `read`, `peek`, `browse`, `verifyEndpoints`). The internal redirect re-validation in `safeFetch` is deliberately unguarded (it passes `skipSsrf` only after its own check).
- **#63 — deepwiki decoder outside safeFetch**: routed through `safeFetch` (DNS-resolving SSRF validation, manual single-hop redirects with target re-validation, timeout, 2 MB cap) via a new `headers` option. The old dead "extracts markdown" test is now a real local round-trip, plus a redirect-refusal test.

## Review

Fable-authored; grok T2 security review ran on the full diff and caught one real regression, fixed in the last commit: **`--danger-disable-ssrf` would have broken in production** (all tests run under `NODE_TEST_CONTEXT`, masking it). The CLI now exports `APITAP_DANGER_DISABLE_SSRF=1` alongside its warning and the guard honors it; the `browse` command site gained the warning it never had. grok's remaining notes (unguarded lower-level `skipSsrf` exports are internal-only by design; scanner findings count as fixed metadata in the #62 bound; `readBodyLimited` char-vs-byte cap is pre-existing) are documented rather than changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X28bnPQoDouurPBZip84NQ