### PR TITLE
apitap doctor — offline skill-store hygiene lint with conservative --fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,21 @@ apitap import https://api.apis.guru/v2/specs/stripe.com/2022-11-15/openapi.json
 
 Imported files are re-signed with your local key. OpenAPI specs are automatically detected and converted using the same merge logic — captured endpoints are preserved, imports fill gaps.
 
+### apitap doctor
+
+Offline hygiene check for your skill store — finds junk domains (ad/WAF/consent
+hosts), tracker beacon endpoints inside good skills, duplicate endpoints, stale
+captures, never-verified endpoints, and unsigned/tampered files.
+
+    apitap doctor              # report only; exit 1 if findings
+    apitap doctor --fix        # apply conservative fixes (quarantine + snapshot)
+    apitap doctor --restore example.com   # undo
+    apitap doctor --json       # machine-readable report
+
+`--fix` never deletes: whole files move to `~/.apitap/skills/.quarantine/`,
+edited files keep a first-touch original under `~/.apitap/skills/.doctor/`.
+Files whose signature does not verify are reported but never edited.
+
 ## Security
 
 ApiTap handles untrusted skill files from the internet and replays HTTP requests on your behalf. That's a high-trust position, and we treat it seriously.
@@ -649,6 +664,7 @@ All commands support `--json` for machine-readable output.
 | `apitap stats` | Show token savings report |
 | `apitap index [domain]` | View passive index from Chrome extension |
 | `apitap audit` | Audit stored skill files and credentials |
+| `apitap doctor` | Offline hygiene check for the skill store (junk domains, beacons, dupes, stale/unsigned files) |
 | `apitap forget <domain>` | Remove skill file and credentials for a domain |
 | `apitap --version` | Print version |
 

--- a/src/capture/parameterize.ts
+++ b/src/capture/parameterize.ts
@@ -128,7 +128,7 @@ const STRUCTURAL_SEGMENTS = new Set<string>([
  * Check if a path segment is a dynamic value based on its structure alone.
  * Returns the parameter name (:id, :hash, :slug) or null if static.
  */
-function classifySegment(segment: string): string | null {
+export function classifySegment(segment: string): string | null {
   // Pure numeric → :id
   if (PURE_NUMERIC_RE.test(segment)) return ':id';
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,9 @@ import { loadKnownSpecs, type KnownSpec } from './known-specs-loader.js';
 import { fetchApisGuruList, filterEntries, fetchSpec } from './skill/apis-guru.js';
 import { searchSwaggerHub, fetchSwaggerHubSpec } from './skill/swaggerhub.js';
 import { buildIndex, removeFromIndex } from './skill/index.js';
+import { runDoctor } from './doctor/index.js';
+import { restoreSkill } from './doctor/snapshot.js';
+import { formatDoctorReport } from './doctor/format.js';
 import {
   resolveGitHubToken,
   searchOrgSpecs,
@@ -114,6 +117,10 @@ function printUsage(): void {
     apitap audit --findings [--source=read|egress] [--scanner=NAME] [--since=ISO] [--json]
                                Query the trap-aware audit log ($XDG_STATE_HOME/apitap/findings.jsonl)
     apitap forget <domain>     Remove skill file and credentials for a domain
+    apitap doctor [domain]     Skill-store hygiene: report junk/dupes/stale (offline)
+      --fix                    Apply conservative fixes (quarantine + snapshot, restorable)
+      --restore <domain>       Undo a doctor fix or quarantine
+      --stale-days <n>         Staleness threshold (default 90)
     apitap stats               Show token savings report
     apitap index build         Rebuild search index (run after manual edits)
     apitap extension install   Register native messaging host for Chrome
@@ -2504,6 +2511,49 @@ async function handleForget(positional: string[]): Promise<void> {
   console.log(`Forgot ${domain} — ${parts.join(' and ')} removed`);
 }
 
+async function handleDoctor(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const skillsDir = SKILLS_DIR || join(APITAP_DIR, 'skills');
+  try {
+    if (typeof flags.restore === 'string') {
+      const source = await restoreSkill(skillsDir, flags.restore);
+      console.log(`Restored ${flags.restore} from ${source === 'orig' ? 'pre-doctor snapshot' : 'quarantine'}`);
+      return;
+    }
+    const machineId = await getEffectiveMachineId();
+    const signingKey = deriveSigningKey(machineId);
+    const staleDays = typeof flags['stale-days'] === 'string' ? Number(flags['stale-days']) : undefined;
+    if (staleDays !== undefined && (!Number.isFinite(staleDays) || staleDays < 0)) {
+      console.error('Error: --stale-days must be a non-negative number');
+      process.exit(2);
+    }
+    const report = await runDoctor({
+      skillsDir, signingKey,
+      fix: flags.fix === true,
+      domain: positional[0],
+      staleDays,
+    });
+    if (flags.json === true) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      console.log(formatDoctorReport(report, flags.fix === true));
+      // Auth orphan info for quarantined domains (report-only; quarantine
+      // deliberately does not touch auth.enc, unlike forget)
+      for (const domain of report.quarantined) {
+        try {
+          const authManager = new AuthManager(APITAP_DIR, machineId);
+          if (await authManager.has(domain)) {
+            console.log(`note: stored credentials for ${domain} kept — run \`apitap forget ${domain}\` if you also want auth gone`);
+          }
+        } catch { /* auth check is best-effort */ }
+      }
+    }
+    process.exit(report.remaining.length > 0 ? 1 : 0);
+  } catch (err: any) {
+    console.error(`Error: ${err.message}`);
+    process.exit(2);
+  }
+}
+
 async function handleIndex(positional: string[]): Promise<void> {
   const subcommand = positional[0];
   if (subcommand !== 'build') {
@@ -2597,6 +2647,9 @@ async function main(): Promise<void> {
       break;
     case 'show':
       await handleShow(positional, flags);
+      break;
+    case 'doctor':
+      await handleDoctor(positional, flags);
       break;
     case 'replay':
       await handleReplay(positional, flags);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2526,16 +2526,32 @@ async function handleDoctor(positional: string[], flags: Record<string, string |
       console.error('Error: --stale-days must be a non-negative number');
       process.exit(2);
     }
+    // The house arg parser greedily assigns the next bare token as a flag's
+    // value, so `--fix polymarket.com` produces flags.fix === 'polymarket.com'
+    // instead of flags.fix === true with 'polymarket.com' as a positional.
+    // Recover intent: a string value still means the boolean flag was set,
+    // and if no positional domain was given, that swallowed string was it.
+    let domain = positional[0];
+    let fixFlag = flags.fix === true;
+    if (typeof flags.fix === 'string') {
+      fixFlag = true;
+      if (domain === undefined) domain = flags.fix;
+    }
+    let jsonFlag = flags.json === true;
+    if (typeof flags.json === 'string') {
+      jsonFlag = true;
+      if (domain === undefined) domain = flags.json;
+    }
     const report = await runDoctor({
       skillsDir, signingKey,
-      fix: flags.fix === true,
-      domain: positional[0],
+      fix: fixFlag,
+      domain,
       staleDays,
     });
-    if (flags.json === true) {
+    if (jsonFlag) {
       console.log(JSON.stringify(report, null, 2));
     } else {
-      console.log(formatDoctorReport(report, flags.fix === true));
+      console.log(formatDoctorReport(report, fixFlag));
       // Auth orphan info for quarantined domains (report-only; quarantine
       // deliberately does not touch auth.enc, unlike forget)
       for (const domain of report.quarantined) {

--- a/src/doctor/checks/beacon-endpoints.ts
+++ b/src/doctor/checks/beacon-endpoints.ts
@@ -1,0 +1,68 @@
+// src/doctor/checks/beacon-endpoints.ts
+import { isBlocklisted } from '../../capture/blocklist.js';
+import type { SkillEndpoint, SkillFile } from '../../types.js';
+import type { Check, EndpointKey, Finding, FixPlan } from '../types.js';
+
+const TRACKER_SEGMENTS = new Set(['capi', 'collect', 'pixel', 'beacon', 'track']);
+
+function hasTrackerSegment(path: string): boolean {
+  return path.split('?')[0].split('/').some(seg => TRACKER_SEGMENTS.has(seg.toLowerCase()));
+}
+
+function targetsBlocklistedHost(ep: SkillEndpoint): boolean {
+  try {
+    return isBlocklisted(new URL(ep.examples.request.url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Offline beacon classifier. SkillEndpoint stores no response status, so
+ * "204/1x1" detection is impossible — we require BOTH a tracker signal
+ * (path segment or blocklisted example host) AND a contentless response
+ * (no responseSchema, and zero bytes or an empty shape). Skeletons are
+ * intentionally body-less and exempt.
+ */
+export function isBeaconShaped(ep: SkillEndpoint): boolean {
+  if (ep.endpointProvenance === 'skeleton') return false;
+  if (ep.responseSchema) return false;
+  const tracker = hasTrackerSegment(ep.path) || targetsBlocklistedHost(ep);
+  if (!tracker) return false;
+  const emptyShape = !ep.responseShape?.fields || ep.responseShape.fields.length === 0;
+  return ep.responseBytes === 0 || emptyShape;
+}
+
+const epKey = (ep: SkillEndpoint): EndpointKey => ({ method: ep.method, path: ep.path });
+
+export const beaconEndpoints: Check = {
+  id: 'beacon-endpoints',
+  title: 'Tracker/beacon endpoints',
+  scan(skill: SkillFile): Finding[] {
+    const beacons = skill.endpoints.filter(isBeaconShaped);
+    const suspects = skill.endpoints.filter(
+      ep => !isBeaconShaped(ep) && (hasTrackerSegment(ep.path) || targetsBlocklistedHost(ep)),
+    );
+    const findings: Finding[] = [];
+    if (beacons.length > 0) {
+      findings.push({
+        checkId: 'beacon-endpoints', domain: skill.domain, severity: 'junk', fixable: true,
+        message: `${beacons.length} tracker endpoint(s): ${beacons.map(e => e.path).join(', ')}`,
+        endpointKeys: beacons.map(epKey),
+      });
+    }
+    if (suspects.length > 0) {
+      findings.push({
+        checkId: 'beacon-endpoints', domain: skill.domain, severity: 'warn', fixable: false,
+        message: `${suspects.length} tracker-like path(s) with real responses (not stripped): ${suspects.map(e => e.path).join(', ')}`,
+        endpointKeys: suspects.map(epKey),
+      });
+    }
+    return findings;
+  },
+  fix(skill: SkillFile): FixPlan {
+    const kept = skill.endpoints.filter(ep => !isBeaconShaped(ep));
+    if (kept.length === 0) return { action: 'quarantine' };
+    return { action: 'edit', skill: { ...skill, endpoints: kept } };
+  },
+};

--- a/src/doctor/checks/duplicate-endpoints.ts
+++ b/src/doctor/checks/duplicate-endpoints.ts
@@ -1,0 +1,109 @@
+// src/doctor/checks/duplicate-endpoints.ts
+import { normalizePath } from '../../skill/merge.js';
+import { TIER_RANK } from '../../skill/search.js';
+import type { SkillEndpoint, SkillFile } from '../../types.js';
+import type { Check, Finding, FixPlan } from '../types.js';
+
+function dupKey(ep: SkillEndpoint): string {
+  let p = normalizePath(ep.path);
+  if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1); // normalizePath keeps trailing slashes
+  return `${ep.method.toUpperCase()} ${p}`;
+}
+
+/**
+ * Richness rank — lower is better on every dimension. There is no
+ * schemaSample field and no per-endpoint timestamp; rank on real fields.
+ */
+function rank(ep: SkillEndpoint): number[] {
+  return [
+    ep.replayability?.verified ? 0 : 1,
+    TIER_RANK[ep.replayability?.tier ?? 'unknown'] ?? 2,
+    ep.responseSchema ? 0 : 1,
+    ep.examples?.responsePreview != null ? 0 : 1,
+    -(ep.responseShape?.fields?.length ?? 0),
+    -(ep.responseBytes ?? 0),
+  ];
+}
+
+const rankLte = (a: number[], b: number[]) => a.every((v, i) => v <= b[i]);
+
+function rankCmp(a: number[], b: number[]): number {
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+
+/** Winner must carry every queryParams key and (for object templates) every requestBody key the loser has. */
+function paramsSuperset(w: SkillEndpoint, l: SkillEndpoint): boolean {
+  for (const k of Object.keys(l.queryParams ?? {})) {
+    if (!(k in (w.queryParams ?? {}))) return false;
+  }
+  if (l.requestBody) {
+    if (!w.requestBody) return false;
+    const lt = l.requestBody.template;
+    const wt = w.requestBody.template;
+    if (typeof lt === 'object' && lt !== null) {
+      if (typeof wt !== 'object' || wt === null) return false;
+      for (const k of Object.keys(lt)) if (!(k in wt)) return false;
+    }
+  }
+  return true;
+}
+
+function dominates(w: SkillEndpoint, l: SkillEndpoint): boolean {
+  return rankLte(rank(w), rank(l)) && paramsSuperset(w, l);
+}
+
+interface Groups { winner: SkillEndpoint; dominated: SkillEndpoint[]; contested: SkillEndpoint[]; }
+
+function groupDuplicates(skill: SkillFile): Map<string, Groups> {
+  const byKey = new Map<string, SkillEndpoint[]>();
+  for (const ep of skill.endpoints) {
+    const k = dupKey(ep);
+    byKey.set(k, [...(byKey.get(k) ?? []), ep]);
+  }
+  const out = new Map<string, Groups>();
+  for (const [k, eps] of byKey) {
+    if (eps.length < 2) continue;
+    const winner = [...eps].sort((a, b) => rankCmp(rank(a), rank(b)))[0];
+    const losers = eps.filter(e => e !== winner);
+    out.set(k, {
+      winner,
+      dominated: losers.filter(l => dominates(winner, l)),
+      contested: losers.filter(l => !dominates(winner, l)),
+    });
+  }
+  return out;
+}
+
+export const duplicateEndpoints: Check = {
+  id: 'duplicate-endpoints',
+  title: 'Duplicate endpoints',
+  scan(skill: SkillFile): Finding[] {
+    const findings: Finding[] = [];
+    for (const [key, g] of groupDuplicates(skill)) {
+      if (g.dominated.length > 0) {
+        findings.push({
+          checkId: 'duplicate-endpoints', domain: skill.domain, severity: 'warn', fixable: true,
+          message: `${key}: ${g.dominated.length + 1} copies → keep ${g.winner.path}, drop dominated duplicate(s)`,
+          endpointKeys: g.dominated.map(e => ({ method: e.method, path: e.path })),
+        });
+      }
+      if (g.contested.length > 0) {
+        findings.push({
+          checkId: 'duplicate-endpoints', domain: skill.domain, severity: 'warn', fixable: false,
+          message: `${key}: duplicate not strictly dominated (unique params/body on the duplicate) — review manually`,
+          endpointKeys: g.contested.map(e => ({ method: e.method, path: e.path })),
+        });
+      }
+    }
+    return findings;
+  },
+  /** Recomputes groups (identity-based) — endpointKeys alone cannot disambiguate exact-same-path dupes. */
+  fix(skill: SkillFile): FixPlan {
+    const drop = new Set<SkillEndpoint>();
+    for (const g of groupDuplicates(skill).values()) {
+      for (const l of g.dominated) drop.add(l);
+    }
+    return { action: 'edit', skill: { ...skill, endpoints: skill.endpoints.filter(e => !drop.has(e)) } };
+  },
+};

--- a/src/doctor/checks/empty-skill.ts
+++ b/src/doctor/checks/empty-skill.ts
@@ -1,0 +1,18 @@
+// src/doctor/checks/empty-skill.ts
+import type { SkillFile } from '../../types.js';
+import type { Check, Finding, FixPlan } from '../types.js';
+
+export const emptySkill: Check = {
+  id: 'empty-skill',
+  title: 'Empty skill files',
+  scan(skill: SkillFile): Finding[] {
+    if (skill.endpoints.length > 0) return [];
+    return [{
+      checkId: 'empty-skill', domain: skill.domain, severity: 'junk', fixable: true,
+      message: 'zero endpoints — no replay value',
+    }];
+  },
+  fix(): FixPlan {
+    return { action: 'quarantine' };
+  },
+};

--- a/src/doctor/checks/invalid-signature.ts
+++ b/src/doctor/checks/invalid-signature.ts
@@ -1,0 +1,21 @@
+// src/doctor/checks/invalid-signature.ts
+import type { Finding, LoadedSkill } from '../types.js';
+
+const MESSAGES: Record<string, string> = {
+  unsigned: 'file is unsigned — hard-verify loads reject it',
+  mismatch: 'signature verification FAILED — possible tampering; edit fixes disabled for this file',
+  expired: 'signature older than 180 days — readSkillFile rejects it; re-capture or re-import',
+  'invalid-file': 'unparseable or structurally invalid skill file',
+};
+
+export function signatureFindings(loaded: LoadedSkill): Finding[] {
+  if (loaded.signatureStatus === 'valid') return [];
+  const detail = loaded.loadError ? ` (${loaded.loadError})` : '';
+  return [{
+    checkId: 'invalid-signature',
+    domain: loaded.domain,
+    severity: 'warn',
+    message: `${MESSAGES[loaded.signatureStatus]}${detail}`,
+    fixable: false, // deliberate: re-signing unverified content would launder tampering
+  }];
+}

--- a/src/doctor/checks/junk-domain.ts
+++ b/src/doctor/checks/junk-domain.ts
@@ -1,0 +1,47 @@
+// src/doctor/checks/junk-domain.ts
+import { isBlocklisted } from '../../capture/blocklist.js';
+import { isBeaconShaped } from './beacon-endpoints.js';
+import type { SkillFile } from '../../types.js';
+import type { Check, Finding, FixPlan } from '../types.js';
+
+/**
+ * Pattern extensions beyond the exact capture blocklist — grown from what the
+ * store actually accumulated (dogfood 2026-07-19). isBlocklisted() covers the
+ * curated exact/parent-domain list; these catch structural junk families.
+ */
+const JUNK_DOMAIN_PATTERNS: RegExp[] = [
+  /(^|\.)awswaf\.com$/i,       // AWS WAF captcha/token/challenge hosts
+  /(^|\.)captcha\./i,          // captcha subdomains anywhere
+  /adsystem/i,                 // aax.amazon-adsystem.com and friends
+  /(^|\.)adsrvr\.org$/i,
+  /(^|\.)onetrust\.com$/i,     // consent/CMP SDKs
+  /(^|\.)cookielaw\.org$/i,
+];
+
+export const junkDomain: Check = {
+  id: 'junk-domain',
+  title: 'Junk domains (ads/tracking/WAF/consent)',
+  scan(skill: SkillFile): Finding[] {
+    const base = { checkId: 'junk-domain', domain: skill.domain };
+    if (isBlocklisted(skill.domain)) {
+      return [{ ...base, severity: 'junk', fixable: true, message: 'domain is on the capture blocklist' }];
+    }
+    if (JUNK_DOMAIN_PATTERNS.some(re => re.test(skill.domain))) {
+      const allBeacon = skill.endpoints.every(isBeaconShaped); // vacuously true for []
+      if (allBeacon) {
+        return [{
+          ...base, severity: 'junk', fixable: true,
+          message: 'junk-pattern domain, no non-beacon endpoints',
+        }];
+      }
+      return [{
+        ...base, severity: 'warn', fixable: false,
+        message: 'junk-pattern domain but carries real data endpoints — review manually',
+      }];
+    }
+    return [];
+  },
+  fix(): FixPlan {
+    return { action: 'quarantine' };
+  },
+};

--- a/src/doctor/checks/stale-capture.ts
+++ b/src/doctor/checks/stale-capture.ts
@@ -1,0 +1,23 @@
+// src/doctor/checks/stale-capture.ts
+import type { SkillFile } from '../../types.js';
+import type { Check, CheckContext, Finding } from '../types.js';
+
+export const staleCapture: Check = {
+  id: 'stale-capture',
+  title: 'Stale captures',
+  scan(skill: SkillFile, ctx: CheckContext): Finding[] {
+    const base = { checkId: 'stale-capture', domain: skill.domain, severity: 'warn' as const, fixable: false };
+    const ts = Date.parse(skill.capturedAt ?? '');
+    if (Number.isNaN(ts)) {
+      return [{ ...base, message: 'missing or unparseable capturedAt' }];
+    }
+    const days = Math.floor((ctx.now.getTime() - ts) / 86_400_000);
+    if (days <= ctx.staleDays) return [];
+    return [{
+      ...base,
+      message:
+        `captured ${skill.capturedAt.slice(0, 10)} (${days} days ago) — re-capture, or verify with --live when available. ` +
+        `Note: file date is an upper bound; merged endpoints may be older.`,
+    }];
+  },
+};

--- a/src/doctor/checks/unparameterized-paths.ts
+++ b/src/doctor/checks/unparameterized-paths.ts
@@ -1,0 +1,37 @@
+// src/doctor/checks/unparameterized-paths.ts
+import { classifySegment } from '../../capture/parameterize.js';
+import type { SkillFile } from '../../types.js';
+import type { Check, Finding } from '../types.js';
+
+/**
+ * Detects >=3 sibling endpoints (same method) whose paths differ in exactly
+ * one segment that classifySegment considers ID-like — evidence that
+ * parameterize.ts missed a family (polymarket resolved-market pattern).
+ * Reuses parameterize's classifier: one taxonomy, not two.
+ */
+export const unparameterizedPaths: Check = {
+  id: 'unparameterized-paths',
+  title: 'Unparameterized endpoint families',
+  scan(skill: SkillFile): Finding[] {
+    const families = new Map<string, Set<string>>();
+    for (const ep of skill.endpoints) {
+      const segs = ep.path.split('?')[0].split('/');
+      segs.forEach((seg, i) => {
+        if (!seg || seg.startsWith(':') || !classifySegment(seg)) return;
+        const family = [...segs.slice(0, i), '*', ...segs.slice(i + 1)].join('/');
+        const key = `${ep.method.toUpperCase()} ${family}`;
+        if (!families.has(key)) families.set(key, new Set());
+        families.get(key)!.add(ep.path);
+      });
+    }
+    const findings: Finding[] = [];
+    for (const [key, paths] of families) {
+      if (paths.size < 3) continue;
+      findings.push({
+        checkId: 'unparameterized-paths', domain: skill.domain, severity: 'info', fixable: false,
+        message: `${paths.size} sibling paths look like an unparameterized family: ${key}`,
+      });
+    }
+    return findings;
+  },
+};

--- a/src/doctor/checks/unverified-tier.ts
+++ b/src/doctor/checks/unverified-tier.ts
@@ -1,0 +1,16 @@
+// src/doctor/checks/unverified-tier.ts
+import type { SkillFile } from '../../types.js';
+import type { Check, Finding } from '../types.js';
+
+export const unverifiedTier: Check = {
+  id: 'unverified-tier',
+  title: 'Never-verified endpoints',
+  scan(skill: SkillFile): Finding[] {
+    const n = skill.endpoints.filter(ep => (ep.replayability?.tier ?? 'unknown') === 'unknown').length;
+    if (n === 0) return [];
+    return [{
+      checkId: 'unverified-tier', domain: skill.domain, severity: 'info', fixable: false,
+      message: `${n} endpoint(s) never verified (tier unknown) — future --live will rank these`,
+    }];
+  },
+};

--- a/src/doctor/format.ts
+++ b/src/doctor/format.ts
@@ -1,0 +1,40 @@
+// src/doctor/format.ts
+import type { DoctorReport, Finding, Severity } from './types.js';
+
+const ORDER: Severity[] = ['junk', 'warn', 'info'];
+const HEADER: Record<Severity, string> = { junk: 'JUNK', warn: 'WARN', info: 'INFO' };
+
+export function formatDoctorReport(report: DoctorReport, fixMode: boolean): string {
+  const lines: string[] = [`apitap doctor — ${report.scanned} skills scanned`, ''];
+  if (report.findings.length === 0) {
+    lines.push('No findings — skill store is clean.');
+    return lines.join('\n');
+  }
+  const fixedKey = new Set(report.fixes.map(f => `${f.domain} ${f.checkId}`));
+  const annotation = (f: Finding): string => {
+    if (!fixMode || !f.fixable || !fixedKey.has(`${f.domain} ${f.checkId}`)) return '';
+    const fix = report.fixes.find(x => x.domain === f.domain && x.checkId === f.checkId)!;
+    return fix.action === 'quarantine' ? '  [QUARANTINED]' : '  [FIXED]';
+  };
+  for (const sev of ORDER) {
+    const group = report.findings.filter(f => f.severity === sev);
+    if (group.length === 0) continue;
+    lines.push(`${HEADER[sev]} (${group.length})`);
+    for (const f of group) {
+      lines.push(`  ${f.domain.padEnd(34)} ${f.checkId}: ${f.message}${annotation(f)}`);
+    }
+    lines.push('');
+  }
+  const fixable = report.findings.filter(f => f.fixable).length;
+  lines.push(`Summary: ${report.findings.length} findings (${fixable} fixable), ${report.fixes.length} fixed, ${report.remaining.length} remaining.`);
+  if (fixMode) {
+    if (report.quarantined.length > 0) {
+      lines.push(`Undo: apitap doctor --restore <domain>  (quarantined: ${report.quarantined.join(', ')})`);
+    } else if (report.fixes.length > 0) {
+      lines.push('Undo: apitap doctor --restore <domain>');
+    }
+  } else if (fixable > 0) {
+    lines.push(`Run \`apitap doctor --fix\` to apply the ${fixable} safe fixes.`);
+  }
+  return lines.join('\n');
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -104,11 +104,31 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorReport> {
 
     const fileFindings = CHECKS.flatMap(c => c.scan(l.skill!, ctx));
     findings.push(...fileFindings);
+
+    // Filename/content domain mismatch: the file on disk is named
+    // <domain>.json but the signed skill payload claims a different domain.
+    // Edits are gated on signature validity, which only proves the bytes
+    // weren't tampered with post-write — it says nothing about whether this
+    // file was placed under someone else's filename. Refuse edit fixes here
+    // too; quarantine still works since it acts on the filename path alone.
+    const domainMismatch = l.skill.domain !== l.domain;
+    if (domainMismatch) {
+      findings.push({
+        checkId: 'domain-mismatch',
+        domain: l.domain,
+        severity: 'warn',
+        message: `file ${l.domain}.json contains a skill for domain "${l.skill.domain}" — ` +
+          `edit fixes disabled for this file (quarantine still applies)`,
+        fixable: false,
+      });
+    }
+
     if (!opts.fix) continue;
 
-    // Integrity gate: edits only on files whose signature verifies —
-    // editing + re-signing anything else would launder tampering.
-    const canEdit = l.signatureStatus === 'valid';
+    // Integrity gate: edits only on files whose signature verifies AND whose
+    // filename matches the signed domain — editing + re-signing anything
+    // else would launder tampering.
+    const canEdit = l.signatureStatus === 'valid' && !domainMismatch;
 
     // Quarantine wins: if any fixable finding plans a quarantine, do only that.
     const fixableIds = new Set(fileFindings.filter(f => f.fixable).map(f => f.checkId));

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -1,0 +1,62 @@
+// src/doctor/index.ts
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { LoadedSkill, SignatureStatus } from './types.js';
+import type { SkillFile } from '../types.js';
+import { validateSkillFile } from '../skill/validate.js';
+import {
+  verifySignature,
+  verifySignatureLegacyCanon,
+  verifySignaturePreProvenance,
+} from '../skill/signing.js';
+
+/** Mirrors store.ts MAX_SIGNATURE_AGE_DAYS (not exported there). */
+const MAX_SIGNATURE_AGE_DAYS = 180;
+
+function signatureStatusOf(skill: SkillFile, key: Buffer, now: Date): SignatureStatus {
+  if (!skill.signature) return 'unsigned';
+  const verified =
+    verifySignature(skill, key) ||
+    verifySignatureLegacyCanon(skill, key) ||
+    verifySignaturePreProvenance(skill, key);
+  if (!verified) return 'mismatch';
+  if (skill.signedAt) {
+    const signedAtMs = Date.parse(skill.signedAt);
+    if (!Number.isNaN(signedAtMs) &&
+        now.getTime() - signedAtMs > MAX_SIGNATURE_AGE_DAYS * 24 * 60 * 60 * 1000) {
+      return 'expired';
+    }
+  }
+  return 'valid';
+}
+
+/**
+ * Doctor's soft loader. Enumerates by readdir of top-level *.json — NOT via
+ * listSkillFiles (index-driven; buildIndex skips unparseable files, which are
+ * exactly the files doctor exists to find). Never throws per-file: a broken
+ * file becomes signatureStatus 'invalid-file' with skill: null.
+ */
+export async function loadSkillsForDoctor(
+  skillsDir: string,
+  signingKey: Buffer,
+  now: Date,
+): Promise<LoadedSkill[]> {
+  const entries = await readdir(skillsDir, { withFileTypes: true });
+  const out: LoadedSkill[] = [];
+  for (const e of entries) {
+    if (!e.isFile() || !e.name.endsWith('.json') || e.name === 'index.json') continue;
+    const domain = e.name.slice(0, -'.json'.length);
+    const filePath = join(skillsDir, e.name);
+    try {
+      const raw = JSON.parse(await readFile(filePath, 'utf-8'));
+      const skill = validateSkillFile(raw);
+      out.push({ domain, filePath, skill, signatureStatus: signatureStatusOf(skill, signingKey, now) });
+    } catch (err) {
+      out.push({
+        domain, filePath, skill: null, signatureStatus: 'invalid-file',
+        loadError: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return out;
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -159,6 +159,9 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorReport> {
   }
 
   const fixedKey = new Set(fixes.map(f => `${f.domain} ${f.checkId}`));
-  const remaining = findings.filter(f => !(f.fixable && fixedKey.has(`${f.domain} ${f.checkId}`)));
+  const quarantinedSet = new Set(quarantined);
+  const remaining = findings.filter(
+    f => !(f.fixable && fixedKey.has(`${f.domain} ${f.checkId}`)) && !quarantinedSet.has(f.domain),
+  );
   return { scanned: loaded.length, findings, fixes, remaining, quarantined };
 }

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -8,7 +8,21 @@ import {
   verifySignature,
   verifySignatureLegacyCanon,
   verifySignaturePreProvenance,
+  signSkillFileAs,
+  provenanceForSigning,
 } from '../skill/signing.js';
+import { writeSkillFile } from '../skill/store.js';
+import { removeFromIndex } from '../skill/index.js';
+import { quarantineSkill, snapshotOnce } from './snapshot.js';
+import { junkDomain } from './checks/junk-domain.js';
+import { beaconEndpoints } from './checks/beacon-endpoints.js';
+import { duplicateEndpoints } from './checks/duplicate-endpoints.js';
+import { staleCapture } from './checks/stale-capture.js';
+import { unverifiedTier } from './checks/unverified-tier.js';
+import { unparameterizedPaths } from './checks/unparameterized-paths.js';
+import { emptySkill } from './checks/empty-skill.js';
+import { signatureFindings } from './checks/invalid-signature.js';
+import type { AppliedFix, Check, CheckContext, DoctorReport, Finding } from './types.js';
 
 /** Mirrors store.ts MAX_SIGNATURE_AGE_DAYS (not exported there). */
 const MAX_SIGNATURE_AGE_DAYS = 180;
@@ -59,4 +73,92 @@ export async function loadSkillsForDoctor(
     }
   }
   return out;
+}
+
+export const CHECKS: Check[] = [
+  junkDomain, beaconEndpoints, duplicateEndpoints, emptySkill,
+  staleCapture, unverifiedTier, unparameterizedPaths,
+];
+
+export interface DoctorOptions {
+  skillsDir: string;
+  signingKey: Buffer;
+  fix?: boolean;
+  domain?: string;
+  staleDays?: number;
+  now?: Date;
+}
+
+export async function runDoctor(opts: DoctorOptions): Promise<DoctorReport> {
+  const ctx: CheckContext = { now: opts.now ?? new Date(), staleDays: opts.staleDays ?? 90 };
+  let loaded = await loadSkillsForDoctor(opts.skillsDir, opts.signingKey, ctx.now);
+  if (opts.domain) loaded = loaded.filter(l => l.domain === opts.domain);
+
+  const findings: Finding[] = [];
+  const fixes: AppliedFix[] = [];
+  const quarantined: string[] = [];
+
+  for (const l of loaded) {
+    findings.push(...signatureFindings(l));
+    if (!l.skill) continue;
+
+    const fileFindings = CHECKS.flatMap(c => c.scan(l.skill!, ctx));
+    findings.push(...fileFindings);
+    if (!opts.fix) continue;
+
+    // Integrity gate: edits only on files whose signature verifies —
+    // editing + re-signing anything else would launder tampering.
+    const canEdit = l.signatureStatus === 'valid';
+
+    // Quarantine wins: if any fixable finding plans a quarantine, do only that.
+    const fixableIds = new Set(fileFindings.filter(f => f.fixable).map(f => f.checkId));
+    let current = l.skill;
+    let edited = false;
+    let doQuarantine = false;
+    let quarantineCheckId = '';
+
+    for (const check of CHECKS) {
+      if (!fixableIds.has(check.id) || !check.fix) continue;
+      // Re-scan against the current (possibly already-edited) skill so
+      // chained fixes don't act on stale findings.
+      const fresh = check.scan(current, ctx).find(f => f.fixable);
+      if (!fresh) continue;
+      const plan = check.fix(current, fresh);
+      if (plan.action === 'quarantine') {
+        doQuarantine = true;
+        quarantineCheckId = check.id;
+        break;
+      }
+      if (!canEdit) continue; // refused: reported but not applied
+      current = plan.skill;
+      edited = true;
+      fixes.push({ domain: l.domain, checkId: check.id, action: 'edit' });
+    }
+
+    if (doQuarantine) {
+      await quarantineSkill(opts.skillsDir, l.domain);
+      try { await removeFromIndex(l.domain, opts.skillsDir); } catch { /* index best-effort */ }
+      quarantined.push(l.domain);
+      fixes.push({ domain: l.domain, checkId: quarantineCheckId, action: 'quarantine' });
+      // edits before a quarantine never hit disk — drop their fix records
+      for (let i = fixes.length - 2; i >= 0; i--) {
+        if (fixes[i].domain === l.domain && fixes[i].action === 'edit') fixes.splice(i, 1);
+      }
+      continue;
+    }
+
+    if (edited) {
+      await snapshotOnce(opts.skillsDir, l.domain);
+      const resigned = signSkillFileAs(
+        { ...current, signature: undefined, signedAt: undefined } as typeof current,
+        opts.signingKey,
+        provenanceForSigning(current),
+      );
+      await writeSkillFile(resigned, opts.skillsDir);
+    }
+  }
+
+  const fixedKey = new Set(fixes.map(f => `${f.domain} ${f.checkId}`));
+  const remaining = findings.filter(f => !(f.fixable && fixedKey.has(`${f.domain} ${f.checkId}`)));
+  return { scanned: loaded.length, findings, fixes, remaining, quarantined };
 }

--- a/src/doctor/snapshot.ts
+++ b/src/doctor/snapshot.ts
@@ -5,11 +5,24 @@ import { join } from 'node:path';
 const QUARANTINE_DIR = '.quarantine';
 const SNAPSHOT_DIR = '.doctor';
 
+/**
+ * Mirrors store.ts's skillPath regex + forget's '..' rejection. Every join()
+ * in this module is derived from `domain`, so this guard confines all of
+ * them to the skills dir — no traversal via crafted --restore/--domain args.
+ */
+function assertValidDomain(domain: string): void {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(domain) || domain.includes('..')) {
+    throw new Error(`Invalid domain: ${domain}`);
+  }
+}
+
 export function quarantinePath(skillsDir: string, domain: string): string {
+  assertValidDomain(domain);
   return join(skillsDir, QUARANTINE_DIR, `${domain}.json`);
 }
 
 export function snapshotPath(skillsDir: string, domain: string): string {
+  assertValidDomain(domain);
   return join(skillsDir, SNAPSHOT_DIR, `${domain}.json.orig`);
 }
 
@@ -19,6 +32,7 @@ async function exists(p: string): Promise<boolean> {
 
 /** Copy the live file to .doctor/<domain>.json.orig — first touch only. */
 export async function snapshotOnce(skillsDir: string, domain: string): Promise<boolean> {
+  assertValidDomain(domain);
   await mkdir(join(skillsDir, SNAPSHOT_DIR), { recursive: true, mode: 0o700 });
   try {
     await copyFile(join(skillsDir, `${domain}.json`), snapshotPath(skillsDir, domain), fsConstants.COPYFILE_EXCL);
@@ -29,10 +43,21 @@ export async function snapshotOnce(skillsDir: string, domain: string): Promise<b
   }
 }
 
-/** Move (never delete) a skill file into quarantine. */
+/**
+ * Move (never delete) a skill file into quarantine. Never clobbers an
+ * existing quarantined copy for the same domain — if the unsuffixed
+ * destination is already taken, move to a timestamped name instead. The
+ * existence check has a tiny TOCTOU window, which is fine under this tool's
+ * same-user threat model.
+ */
 export async function quarantineSkill(skillsDir: string, domain: string): Promise<void> {
+  assertValidDomain(domain);
   await mkdir(join(skillsDir, QUARANTINE_DIR), { recursive: true, mode: 0o700 });
-  await rename(join(skillsDir, `${domain}.json`), quarantinePath(skillsDir, domain));
+  const dest = quarantinePath(skillsDir, domain);
+  const target = (await exists(dest))
+    ? join(skillsDir, QUARANTINE_DIR, `${domain}.${Date.now()}.json`)
+    : dest;
+  await rename(join(skillsDir, `${domain}.json`), target);
 }
 
 /**
@@ -41,6 +66,7 @@ export async function quarantineSkill(skillsDir: string, domain: string): Promis
  * file exists (re-captured after quarantine). Bytes verbatim, never re-signs.
  */
 export async function restoreSkill(skillsDir: string, domain: string): Promise<'orig' | 'quarantine'> {
+  assertValidDomain(domain);
   const live = join(skillsDir, `${domain}.json`);
   const orig = snapshotPath(skillsDir, domain);
   const quar = quarantinePath(skillsDir, domain);

--- a/src/doctor/snapshot.ts
+++ b/src/doctor/snapshot.ts
@@ -1,0 +1,62 @@
+import { mkdir, rename, copyFile, access } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { join } from 'node:path';
+
+const QUARANTINE_DIR = '.quarantine';
+const SNAPSHOT_DIR = '.doctor';
+
+export function quarantinePath(skillsDir: string, domain: string): string {
+  return join(skillsDir, QUARANTINE_DIR, `${domain}.json`);
+}
+
+export function snapshotPath(skillsDir: string, domain: string): string {
+  return join(skillsDir, SNAPSHOT_DIR, `${domain}.json.orig`);
+}
+
+async function exists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+/** Copy the live file to .doctor/<domain>.json.orig — first touch only. */
+export async function snapshotOnce(skillsDir: string, domain: string): Promise<boolean> {
+  await mkdir(join(skillsDir, SNAPSHOT_DIR), { recursive: true, mode: 0o700 });
+  try {
+    await copyFile(join(skillsDir, `${domain}.json`), snapshotPath(skillsDir, domain), fsConstants.COPYFILE_EXCL);
+    return true;
+  } catch (err: any) {
+    if (err?.code === 'EEXIST') return false;
+    throw err;
+  }
+}
+
+/** Move (never delete) a skill file into quarantine. */
+export async function quarantineSkill(skillsDir: string, domain: string): Promise<void> {
+  await mkdir(join(skillsDir, QUARANTINE_DIR), { recursive: true, mode: 0o700 });
+  await rename(join(skillsDir, `${domain}.json`), quarantinePath(skillsDir, domain));
+}
+
+/**
+ * Restore rules (spec): .orig wins (oldest pre-doctor original, overwrites a
+ * doctor-edited live file by design); quarantine restore refuses when a live
+ * file exists (re-captured after quarantine). Bytes verbatim, never re-signs.
+ */
+export async function restoreSkill(skillsDir: string, domain: string): Promise<'orig' | 'quarantine'> {
+  const live = join(skillsDir, `${domain}.json`);
+  const orig = snapshotPath(skillsDir, domain);
+  const quar = quarantinePath(skillsDir, domain);
+  if (await exists(orig)) {
+    await copyFile(orig, live);
+    return 'orig';
+  }
+  if (await exists(quar)) {
+    if (await exists(live)) {
+      throw new Error(
+        `refusing to overwrite live skill for ${domain} — it was re-captured after quarantine. ` +
+        `The quarantined copy stays at ${quar}.`,
+      );
+    }
+    await rename(quar, live);
+    return 'quarantine';
+  }
+  throw new Error(`nothing to restore for ${domain}`);
+}

--- a/src/doctor/types.ts
+++ b/src/doctor/types.ts
@@ -1,0 +1,60 @@
+// src/doctor/types.ts
+import type { SkillFile } from '../types.js';
+
+export type Severity = 'junk' | 'warn' | 'info';
+
+export interface EndpointKey {
+  method: string;
+  path: string;
+}
+
+export interface Finding {
+  checkId: string;
+  domain: string;
+  severity: Severity;
+  message: string;
+  endpointKeys?: EndpointKey[];
+  fixable: boolean;
+}
+
+export type FixPlan =
+  | { action: 'quarantine' }
+  | { action: 'edit'; skill: SkillFile };
+
+export interface CheckContext {
+  now: Date;
+  staleDays: number;
+}
+
+export interface Check {
+  id: string;
+  title: string;
+  /** Pure: never touches disk. */
+  scan(skill: SkillFile, ctx: CheckContext): Finding[];
+  /** Pure: returns a plan; the engine does all I/O. */
+  fix?(skill: SkillFile, finding: Finding): FixPlan;
+}
+
+export type SignatureStatus = 'valid' | 'unsigned' | 'mismatch' | 'expired' | 'invalid-file';
+
+export interface LoadedSkill {
+  domain: string; // from filename
+  filePath: string;
+  skill: SkillFile | null; // null when unparseable/invalid
+  signatureStatus: SignatureStatus;
+  loadError?: string;
+}
+
+export interface AppliedFix {
+  domain: string;
+  checkId: string;
+  action: 'quarantine' | 'edit';
+}
+
+export interface DoctorReport {
+  scanned: number;
+  findings: Finding[];
+  fixes: AppliedFix[];
+  remaining: Finding[];
+  quarantined: string[];
+}

--- a/src/skill/search.ts
+++ b/src/skill/search.ts
@@ -28,7 +28,7 @@ const DEFAULT_LIMIT = 50;
 const SUGGESTION_DOMAIN_CAP = 20;
 
 /** Lower rank = kept first when truncating */
-const TIER_RANK: Record<string, number> = { green: 0, yellow: 1, unknown: 2, orange: 3, red: 4 };
+export const TIER_RANK: Record<string, number> = { green: 0, yellow: 1, unknown: 2, orange: 3, red: 4 };
 
 /**
  * Check if a search term matches a target string.

--- a/test/doctor/checks/beacon-endpoints.test.ts
+++ b/test/doctor/checks/beacon-endpoints.test.ts
@@ -1,0 +1,80 @@
+// test/doctor/checks/beacon-endpoints.test.ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { beaconEndpoints, isBeaconShaped } from '../../../src/doctor/checks/beacon-endpoints.js';
+import { makeEndpoint, makeSkill } from '../fixtures.js';
+
+const CTX = { now: new Date('2026-07-19T00:00:00.000Z'), staleDays: 90 };
+
+const beacon = () => makeEndpoint({
+  id: 'post-capi', method: 'POST', path: '/capi/meta',
+  responseShape: { type: 'object' },          // no fields
+  responseBytes: 0,
+  examples: { request: { url: 'https://polymarket.com/capi/meta', headers: {} }, responsePreview: null },
+});
+
+describe('isBeaconShaped', () => {
+  it('flags tracker path + contentless response', () => {
+    assert.equal(isBeaconShaped(beacon()), true);
+  });
+  it('does NOT flag a data endpoint on a tracker-like path (has responseSchema)', () => {
+    const ep = makeEndpoint({
+      path: '/api/collect',
+      responseSchema: { type: 'object', fields: { id: { type: 'number' } } },
+    });
+    assert.equal(isBeaconShaped(ep), false);
+  });
+  it('does NOT flag shipment tracking with real fields', () => {
+    const ep = makeEndpoint({ path: '/api/track/12345', responseShape: { type: 'object', fields: ['status', 'eta'] } });
+    assert.equal(isBeaconShaped(ep), false);
+  });
+  it('does NOT flag skeleton-provenance endpoints', () => {
+    const ep = makeEndpoint({ path: '/collect', endpointProvenance: 'skeleton', responseShape: { type: 'object' } });
+    assert.equal(isBeaconShaped(ep), false);
+  });
+  it('does not substring-match: /tracking is not the segment "track"', () => {
+    const ep = makeEndpoint({ path: '/api/trackingnumbers', responseShape: { type: 'object' }, responseBytes: 0 });
+    assert.equal(isBeaconShaped(ep), false);
+  });
+  it('flags contentless endpoint whose example URL host is blocklisted', () => {
+    const ep = makeEndpoint({
+      path: '/v1/events', responseShape: { type: 'object' }, responseBytes: 0,
+      examples: { request: { url: 'https://api.mixpanel.com/v1/events', headers: {} }, responsePreview: null },
+    });
+    assert.equal(isBeaconShaped(ep), true);
+  });
+});
+
+describe('beaconEndpoints check', () => {
+  it('emits a fixable junk finding for beacons and a warn for path-only suspects', () => {
+    const suspect = makeEndpoint({ id: 'get-collect', path: '/api/collect' }); // real fields → suspect only
+    const skill = makeSkill({ endpoints: [makeEndpoint(), beacon(), suspect] });
+    const findings = beaconEndpoints.scan(skill, CTX);
+    const junk = findings.find(f => f.severity === 'junk')!;
+    const warn = findings.find(f => f.severity === 'warn')!;
+    assert.equal(junk.fixable, true);
+    assert.deepEqual(junk.endpointKeys, [{ method: 'POST', path: '/capi/meta' }]);
+    assert.equal(warn.fixable, false);
+  });
+
+  it('fix strips flagged endpoints and keeps the rest', () => {
+    const skill = makeSkill({ endpoints: [makeEndpoint(), beacon()] });
+    const [junk] = beaconEndpoints.scan(skill, CTX).filter(f => f.fixable);
+    const plan = beaconEndpoints.fix!(skill, junk);
+    assert.equal(plan.action, 'edit');
+    if (plan.action === 'edit') {
+      assert.equal(plan.skill.endpoints.length, 1);
+      assert.equal(plan.skill.endpoints[0].path, '/api/items');
+    }
+  });
+
+  it('fix escalates to quarantine when stripping would leave zero endpoints', () => {
+    const skill = makeSkill({ endpoints: [beacon()] });
+    const [junk] = beaconEndpoints.scan(skill, CTX).filter(f => f.fixable);
+    assert.deepEqual(beaconEndpoints.fix!(skill, junk), { action: 'quarantine' });
+  });
+
+  it('clean skill → no findings', () => {
+    assert.deepEqual(beaconEndpoints.scan(makeSkill(), CTX), []);
+  });
+});

--- a/test/doctor/checks/duplicate-endpoints.test.ts
+++ b/test/doctor/checks/duplicate-endpoints.test.ts
@@ -1,0 +1,72 @@
+// test/doctor/checks/duplicate-endpoints.test.ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { duplicateEndpoints } from '../../../src/doctor/checks/duplicate-endpoints.js';
+import { makeEndpoint, makeSkill } from '../fixtures.js';
+
+const CTX = { now: new Date('2026-07-19T00:00:00.000Z'), staleDays: 90 };
+
+describe('duplicate-endpoints', () => {
+  it('drops a strictly dominated duplicate (gamma-api pattern)', () => {
+    const winner = makeEndpoint({
+      id: 'get-events', path: '/events/:id',
+      replayability: { tier: 'green', verified: true, signals: [] },
+      responseSchema: { type: 'object', fields: { id: { type: 'number' } } },
+      queryParams: { limit: { type: 'number', example: '10' } },
+    });
+    const loser = makeEndpoint({
+      id: 'get-events-2', path: '/events/:eventId',   // same after normalizePath
+      replayability: { tier: 'unknown', verified: false, signals: [] },
+      queryParams: {},
+    });
+    const skill = makeSkill({ endpoints: [winner, loser] });
+    const findings = duplicateEndpoints.scan(skill, CTX);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].fixable, true);
+    assert.deepEqual(findings[0].endpointKeys, [{ method: 'GET', path: '/events/:eventId' }]);
+    const plan = duplicateEndpoints.fix!(skill, findings[0]);
+    assert.equal(plan.action, 'edit');
+    if (plan.action === 'edit') {
+      assert.equal(plan.skill.endpoints.length, 1);
+      assert.equal(plan.skill.endpoints[0].path, '/events/:id');
+    }
+  });
+
+  it('trailing-slash variants are the same group', () => {
+    const a = makeEndpoint({ path: '/events/', replayability: { tier: 'green', verified: true, signals: [] } });
+    const b = makeEndpoint({ path: '/events' });
+    const findings = duplicateEndpoints.scan(makeSkill({ endpoints: [a, b] }), CTX);
+    assert.equal(findings.length, 1);
+  });
+
+  it('NON-dominated duplicate (loser has a queryParam the winner lacks) → report-only', () => {
+    const a = makeEndpoint({
+      path: '/events/:id',
+      replayability: { tier: 'green', verified: true, signals: [] },
+      queryParams: {},
+    });
+    const b = makeEndpoint({
+      path: '/events/:eventId',
+      queryParams: { archived: { type: 'boolean', example: 'true' } }, // only copy of this param
+    });
+    const findings = duplicateEndpoints.scan(makeSkill({ endpoints: [a, b] }), CTX);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].fixable, false);
+  });
+
+  it('loser with a requestBody the winner lacks → report-only', () => {
+    const a = makeEndpoint({ method: 'POST', path: '/orders/:id', replayability: { tier: 'green', verified: true, signals: [] } });
+    const b = makeEndpoint({
+      method: 'POST', path: '/orders/:orderId',
+      requestBody: { contentType: 'application/json', template: { qty: 1 } },
+    });
+    const findings = duplicateEndpoints.scan(makeSkill({ endpoints: [a, b] }), CTX);
+    assert.equal(findings[0].fixable, false);
+  });
+
+  it('different methods are different groups; unique endpoints → no findings', () => {
+    const a = makeEndpoint({ method: 'GET', path: '/events/:id' });
+    const b = makeEndpoint({ method: 'POST', path: '/events/:id' });
+    assert.deepEqual(duplicateEndpoints.scan(makeSkill({ endpoints: [a, b] }), CTX), []);
+  });
+});

--- a/test/doctor/checks/junk-domain.test.ts
+++ b/test/doctor/checks/junk-domain.test.ts
@@ -1,0 +1,51 @@
+// test/doctor/checks/junk-domain.test.ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { junkDomain } from '../../../src/doctor/checks/junk-domain.js';
+import { makeEndpoint, makeSkill } from '../fixtures.js';
+
+const CTX = { now: new Date('2026-07-19T00:00:00.000Z'), staleDays: 90 };
+
+const beaconEp = () => makeEndpoint({
+  method: 'POST', path: '/collect', responseShape: { type: 'object' }, responseBytes: 0,
+  examples: { request: { url: 'https://x.example/collect', headers: {} }, responsePreview: null },
+});
+
+describe('junk-domain', () => {
+  it('blocklisted domain (incl. subdomain of blocklist entry) → fixable junk', () => {
+    const skill = makeSkill({ domain: 'cdn.segment.com', baseUrl: 'https://cdn.segment.com' });
+    const [f] = junkDomain.scan(skill, CTX);
+    assert.equal(f.severity, 'junk');
+    assert.equal(f.fixable, true);
+  });
+
+  it('pattern domain with ALL endpoints beacon-shaped → fixable junk', () => {
+    const skill = makeSkill({
+      domain: '22af.captcha.awswaf.com', baseUrl: 'https://22af.captcha.awswaf.com',
+      endpoints: [beaconEp()],
+    });
+    const [f] = junkDomain.scan(skill, CTX);
+    assert.equal(f.severity, 'junk');
+    assert.equal(f.fixable, true);
+  });
+
+  it('pattern domain with a real data endpoint → warn, report-only', () => {
+    const skill = makeSkill({
+      domain: 'api.adsystemtools.com', baseUrl: 'https://api.adsystemtools.com',
+      endpoints: [beaconEp(), makeEndpoint()],
+    });
+    const [f] = junkDomain.scan(skill, CTX);
+    assert.equal(f.severity, 'warn');
+    assert.equal(f.fixable, false);
+  });
+
+  it('normal domain → no findings', () => {
+    assert.deepEqual(junkDomain.scan(makeSkill(), CTX), []);
+  });
+
+  it('fix is quarantine', () => {
+    const skill = makeSkill({ domain: 'cdn.segment.com', baseUrl: 'https://cdn.segment.com' });
+    const [f] = junkDomain.scan(skill, CTX);
+    assert.deepEqual(junkDomain.fix!(skill, f), { action: 'quarantine' });
+  });
+});

--- a/test/doctor/checks/small-checks.test.ts
+++ b/test/doctor/checks/small-checks.test.ts
@@ -1,0 +1,61 @@
+// test/doctor/checks/small-checks.test.ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { staleCapture } from '../../../src/doctor/checks/stale-capture.js';
+import { unverifiedTier } from '../../../src/doctor/checks/unverified-tier.js';
+import { emptySkill } from '../../../src/doctor/checks/empty-skill.js';
+import { makeEndpoint, makeSkill } from '../fixtures.js';
+
+const CTX = { now: new Date('2026-07-19T00:00:00.000Z'), staleDays: 90 };
+
+describe('stale-capture', () => {
+  it('flags captures older than staleDays', () => {
+    const [f] = staleCapture.scan(makeSkill({ capturedAt: '2026-03-14T00:00:00.000Z' }), CTX);
+    assert.equal(f.severity, 'warn');
+    assert.equal(f.fixable, false);
+    assert.match(f.message, /127 days/);
+    assert.match(f.message, /upper bound/); // merged endpoints may be older
+  });
+  it('fresh capture → no finding; missing capturedAt → warn', () => {
+    assert.deepEqual(staleCapture.scan(makeSkill({ capturedAt: '2026-07-01T00:00:00.000Z' }), CTX), []);
+    const [f] = staleCapture.scan(makeSkill({ capturedAt: 'not-a-date' }), CTX);
+    assert.match(f.message, /capturedAt/);
+  });
+  it('respects a custom staleDays', () => {
+    const ctx = { ...CTX, staleDays: 10 };
+    assert.equal(staleCapture.scan(makeSkill({ capturedAt: '2026-07-01T00:00:00.000Z' }), ctx).length, 1);
+  });
+});
+
+describe('unverified-tier', () => {
+  it('one info finding per skill counting unknown-tier endpoints (missing replayability counts)', () => {
+    const skill = makeSkill({
+      endpoints: [
+        makeEndpoint({ replayability: { tier: 'green', verified: true, signals: [] } }),
+        makeEndpoint({ id: 'e2', path: '/a', replayability: { tier: 'unknown', verified: false, signals: [] } }),
+        makeEndpoint({ id: 'e3', path: '/b' }), // no replayability at all
+      ],
+    });
+    const findings = unverifiedTier.scan(skill, CTX);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].severity, 'info');
+    assert.match(findings[0].message, /2 endpoint/);
+  });
+  it('all verified → none', () => {
+    const skill = makeSkill({ endpoints: [makeEndpoint({ replayability: { tier: 'green', verified: true, signals: [] } })] });
+    assert.deepEqual(unverifiedTier.scan(skill, CTX), []);
+  });
+});
+
+describe('empty-skill', () => {
+  it('zero endpoints → fixable junk, fix is quarantine', () => {
+    const skill = makeSkill({ endpoints: [] });
+    const [f] = emptySkill.scan(skill, CTX);
+    assert.equal(f.severity, 'junk');
+    assert.equal(f.fixable, true);
+    assert.deepEqual(emptySkill.fix!(skill, f), { action: 'quarantine' });
+  });
+  it('non-empty → none', () => {
+    assert.deepEqual(emptySkill.scan(makeSkill(), CTX), []);
+  });
+});

--- a/test/doctor/checks/unparameterized-paths.test.ts
+++ b/test/doctor/checks/unparameterized-paths.test.ts
@@ -1,0 +1,48 @@
+// test/doctor/checks/unparameterized-paths.test.ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { unparameterizedPaths } from '../../../src/doctor/checks/unparameterized-paths.js';
+import { makeEndpoint, makeSkill } from '../fixtures.js';
+
+const CTX = { now: new Date('2026-07-19T00:00:00.000Z'), staleDays: 90 };
+
+describe('unparameterized-paths', () => {
+  it('flags >=3 siblings differing in one ID-like segment (resolved-market pattern)', () => {
+    const skill = makeSkill({
+      endpoints: [
+        makeEndpoint({ id: 'm1', path: '/markets/btc-updown-15m-1770254100' }),
+        makeEndpoint({ id: 'm2', path: '/markets/eth-updown-15m-1770254200' }),
+        makeEndpoint({ id: 'm3', path: '/markets/sol-updown-15m-1770254300' }),
+      ],
+    });
+    const findings = unparameterizedPaths.scan(skill, CTX);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].severity, 'info');
+    assert.equal(findings[0].fixable, false);
+    assert.match(findings[0].message, /3 sibling/);
+    assert.match(findings[0].message, /GET \/markets\/\*/);
+  });
+
+  it('two siblings are not enough; already-parameterized paths never flag', () => {
+    const two = makeSkill({
+      endpoints: [
+        makeEndpoint({ id: 'a', path: '/markets/1770254100' }),
+        makeEndpoint({ id: 'b', path: '/markets/1770254200' }),
+      ],
+    });
+    assert.deepEqual(unparameterizedPaths.scan(two, CTX), []);
+    const param = makeSkill({ endpoints: [makeEndpoint({ path: '/markets/:id' })] });
+    assert.deepEqual(unparameterizedPaths.scan(param, CTX), []);
+  });
+
+  it('static word segments never form a family', () => {
+    const skill = makeSkill({
+      endpoints: [
+        makeEndpoint({ id: 'a', path: '/api/users' }),
+        makeEndpoint({ id: 'b', path: '/api/teams' }),
+        makeEndpoint({ id: 'c', path: '/api/orders' }),
+      ],
+    });
+    assert.deepEqual(unparameterizedPaths.scan(skill, CTX), []);
+  });
+});

--- a/test/doctor/cli.test.ts
+++ b/test/doctor/cli.test.ts
@@ -1,0 +1,48 @@
+// test/doctor/cli.test.ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { formatDoctorReport } from '../../src/doctor/format.js';
+import type { DoctorReport } from '../../src/doctor/types.js';
+
+const report: DoctorReport = {
+  scanned: 3,
+  findings: [
+    { checkId: 'junk-domain', domain: 'cdn.segment.com', severity: 'junk', fixable: true, message: 'domain is on the capture blocklist' },
+    { checkId: 'stale-capture', domain: 'zillow.com', severity: 'warn', fixable: false, message: 'captured 2026-03-14 (127 days ago) — re-capture' },
+    { checkId: 'unverified-tier', domain: 'zillow.com', severity: 'info', fixable: false, message: '5 endpoint(s) never verified (tier unknown)' },
+  ],
+  fixes: [],
+  remaining: [],
+  quarantined: [],
+};
+
+describe('formatDoctorReport', () => {
+  it('groups by severity junk > warn > info with a summary and --fix hint', () => {
+    const out = formatDoctorReport(report, false);
+    const junkIdx = out.indexOf('JUNK');
+    const warnIdx = out.indexOf('WARN');
+    const infoIdx = out.indexOf('INFO');
+    assert.ok(junkIdx >= 0 && junkIdx < warnIdx && warnIdx < infoIdx);
+    assert.match(out, /3 skills scanned/);
+    assert.match(out, /apitap doctor --fix/);
+    assert.match(out, /cdn\.segment\.com/);
+  });
+
+  it('fix mode annotates applied fixes and shows the restore hint', () => {
+    const fixed: DoctorReport = {
+      ...report,
+      fixes: [{ domain: 'cdn.segment.com', checkId: 'junk-domain', action: 'quarantine' }],
+      quarantined: ['cdn.segment.com'],
+      remaining: report.findings.slice(1),
+    };
+    const out = formatDoctorReport(fixed, true);
+    assert.match(out, /QUARANTINED/);
+    assert.match(out, /apitap doctor --restore/);
+    assert.doesNotMatch(out, /apitap doctor --fix/); // no hint when already fixing
+  });
+
+  it('clean report says so', () => {
+    const clean: DoctorReport = { scanned: 5, findings: [], fixes: [], remaining: [], quarantined: [] };
+    assert.match(formatDoctorReport(clean, false), /no findings/i);
+  });
+});

--- a/test/doctor/engine.test.ts
+++ b/test/doctor/engine.test.ts
@@ -129,4 +129,30 @@ describe('runDoctor', () => {
       await rm(multiDir, { recursive: true, force: true });
     }
   });
+
+  it('refuses edit fixes when the filename domain does not match the signed skill.domain', async () => {
+    // Validly-signed skill claims domain 'real.com' but is saved under a
+    // different basename — a filename/content mismatch that signature
+    // verification alone would not catch.
+    const mismatchDir = await mkdtemp(join(tmpdir(), 'doctor-engine-mismatch-'));
+    try {
+      const skill = signSkillFileAs(makeSkill({
+        domain: 'real.com', baseUrl: 'https://real.com',
+        endpoints: [makeEndpoint(), beaconEp()],
+      }), key, 'self');
+      const filePath = join(mismatchDir, 'alias.com.json');
+      const before = JSON.stringify(skill);
+      await writeFile(filePath, before);
+
+      const report = await runDoctor({ skillsDir: mismatchDir, signingKey: key, fix: true, now: NOW });
+
+      // bytes unchanged — no edit, no re-sign
+      assert.equal(await readFile(filePath, 'utf-8'), before);
+      assert.ok(report.findings.some(
+        f => f.checkId === 'domain-mismatch' && f.domain === 'alias.com' && f.severity === 'warn' && f.fixable === false,
+      ));
+    } finally {
+      await rm(mismatchDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/doctor/engine.test.ts
+++ b/test/doctor/engine.test.ts
@@ -100,4 +100,33 @@ describe('runDoctor', () => {
     assert.equal(report.scanned, 1);
     assert.equal(report.findings.length, 0);
   });
+
+  it('quarantine drops ALL of that domain\'s findings from remaining, not just the quarantine trigger', async () => {
+    // A skill that is simultaneously: on the junk-domain blocklist, has a
+    // beacon endpoint, and is unsigned — so scanning it produces
+    // invalid-signature + beacon-endpoints + junk-domain findings. Only one
+    // of those (junk-domain) drives the quarantine action; the file is gone
+    // afterward, so the other findings must not survive into `remaining`.
+    const multiDir = await mkdtemp(join(tmpdir(), 'doctor-engine-multi-'));
+    try {
+      const unsigned = makeSkill({
+        domain: 'cdn.segment.com', baseUrl: 'https://cdn.segment.com',
+        endpoints: [makeEndpoint(), beaconEp()],
+      });
+      (unsigned as any).signature = undefined;
+      (unsigned as any).signedAt = undefined;
+      await writeFile(join(multiDir, 'cdn.segment.com.json'), JSON.stringify(unsigned));
+
+      const scanOnly = await runDoctor({ skillsDir: multiDir, signingKey: key, now: NOW });
+      assert.ok(scanOnly.findings.some(f => f.domain === 'cdn.segment.com' && f.checkId === 'junk-domain'));
+      assert.ok(scanOnly.findings.some(f => f.domain === 'cdn.segment.com' && f.checkId === 'beacon-endpoints'));
+      assert.ok(scanOnly.findings.some(f => f.domain === 'cdn.segment.com' && f.checkId === 'invalid-signature'));
+
+      const report = await runDoctor({ skillsDir: multiDir, signingKey: key, fix: true, now: NOW });
+      assert.deepEqual(report.quarantined, ['cdn.segment.com']);
+      assert.equal(report.remaining.some(f => f.domain === 'cdn.segment.com'), false);
+    } finally {
+      await rm(multiDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/doctor/engine.test.ts
+++ b/test/doctor/engine.test.ts
@@ -1,0 +1,103 @@
+// test/doctor/engine.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdtemp, writeFile, readFile, rm, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { runDoctor } from '../../src/doctor/index.js';
+import { quarantinePath, snapshotPath } from '../../src/doctor/snapshot.js';
+import { signSkillFileAs, verifySignature } from '../../src/skill/signing.js';
+import { readSkillFile } from '../../src/skill/store.js';
+import { makeEndpoint, makeSkill } from './fixtures.js';
+
+const NOW = new Date('2026-07-19T00:00:00.000Z');
+
+async function exists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+describe('runDoctor', () => {
+  let dir: string;
+  const key = randomBytes(32);
+
+  const beaconEp = () => makeEndpoint({
+    id: 'post-capi', method: 'POST', path: '/capi/meta',
+    responseShape: { type: 'object' }, responseBytes: 0,
+    examples: { request: { url: 'https://mixed.com/capi/meta', headers: {} }, responsePreview: null },
+  });
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'doctor-engine-'));
+    // junk domain (on capture blocklist) → quarantine
+    await writeFile(join(dir, 'cdn.segment.com.json'),
+      JSON.stringify(signSkillFileAs(makeSkill({ domain: 'cdn.segment.com', baseUrl: 'https://cdn.segment.com' }), key, 'self')));
+    // good skill with one beacon endpoint → edit + re-sign
+    await writeFile(join(dir, 'mixed.com.json'),
+      JSON.stringify(signSkillFileAs(makeSkill({
+        domain: 'mixed.com', baseUrl: 'https://mixed.com',
+        endpoints: [makeEndpoint(), beaconEp()],
+      }), key, 'self')));
+    // TAMPERED skill with a beacon endpoint → edit must be REFUSED
+    const tampered = signSkillFileAs(makeSkill({
+      domain: 'tampered.com', baseUrl: 'https://tampered.com',
+      endpoints: [makeEndpoint(), beaconEp()],
+    }), key, 'self');
+    (tampered as any).capturedAt = '2026-07-02T00:00:00.000Z'; // break the HMAC
+    await writeFile(join(dir, 'tampered.com.json'), JSON.stringify(tampered));
+    // clean skill → untouched (verified endpoint so unverified-tier stays quiet)
+    await writeFile(join(dir, 'clean.com.json'),
+      JSON.stringify(signSkillFileAs(makeSkill({
+        domain: 'clean.com', baseUrl: 'https://clean.com',
+        endpoints: [makeEndpoint({ replayability: { tier: 'green', verified: true, signals: [] } })],
+      }), key, 'self')));
+  });
+  afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it('scan-only reports findings and mutates nothing', async () => {
+    const before = await readFile(join(dir, 'mixed.com.json'), 'utf-8');
+    const report = await runDoctor({ skillsDir: dir, signingKey: key, now: NOW });
+    assert.equal(report.scanned, 4);
+    assert.equal(report.fixes.length, 0);
+    assert.ok(report.findings.some(f => f.checkId === 'junk-domain' && f.domain === 'cdn.segment.com'));
+    assert.ok(report.findings.some(f => f.checkId === 'beacon-endpoints' && f.domain === 'mixed.com'));
+    assert.ok(report.findings.some(f => f.checkId === 'invalid-signature' && f.domain === 'tampered.com'));
+    assert.equal(await readFile(join(dir, 'mixed.com.json'), 'utf-8'), before);
+  });
+
+  it('--fix quarantines junk, edits+re-signs mixed, refuses edits on tampered', async () => {
+    const report = await runDoctor({ skillsDir: dir, signingKey: key, fix: true, now: NOW });
+
+    // junk quarantined
+    assert.equal(await exists(join(dir, 'cdn.segment.com.json')), false);
+    assert.equal(await exists(quarantinePath(dir, 'cdn.segment.com')), true);
+    assert.deepEqual(report.quarantined, ['cdn.segment.com']);
+
+    // mixed edited: beacon stripped, snapshot exists, re-signed with valid provenance-aware signature
+    assert.equal(await exists(snapshotPath(dir, 'mixed.com')), true);
+    const mixed = JSON.parse(await readFile(join(dir, 'mixed.com.json'), 'utf-8'));
+    assert.equal(mixed.endpoints.length, 1);
+    assert.equal(mixed.provenance, 'self');
+    assert.equal(verifySignature(mixed, key), true);
+    // and store.ts hard-verify still loads it
+    await readSkillFile('mixed.com', dir, { verifySignature: true, signingKey: key });
+
+    // tampered: NOT edited, NOT re-signed
+    const tampered = JSON.parse(await readFile(join(dir, 'tampered.com.json'), 'utf-8'));
+    assert.equal(tampered.endpoints.length, 2);
+    assert.equal(verifySignature(tampered, key), false);
+
+    // clean untouched, no snapshot
+    assert.equal(await exists(snapshotPath(dir, 'clean.com')), false);
+
+    // remaining excludes fixed findings but keeps tampered's
+    assert.ok(report.remaining.some(f => f.domain === 'tampered.com'));
+    assert.ok(!report.remaining.some(f => f.domain === 'cdn.segment.com' && f.checkId === 'junk-domain'));
+  });
+
+  it('domain filter scopes the run', async () => {
+    const report = await runDoctor({ skillsDir: dir, signingKey: key, domain: 'clean.com', now: NOW });
+    assert.equal(report.scanned, 1);
+    assert.equal(report.findings.length, 0);
+  });
+});

--- a/test/doctor/fixtures.ts
+++ b/test/doctor/fixtures.ts
@@ -1,0 +1,31 @@
+// test/doctor/fixtures.ts
+import type { SkillEndpoint, SkillFile } from '../../src/types.js';
+
+export function makeEndpoint(over: Partial<SkillEndpoint> = {}): SkillEndpoint {
+  return {
+    id: 'get-items',
+    method: 'GET',
+    path: '/api/items',
+    queryParams: {},
+    headers: {},
+    responseShape: { type: 'object', fields: ['id', 'name'] },
+    examples: {
+      request: { url: 'https://example.com/api/items', headers: {} },
+      responsePreview: { id: 1, name: 'x' },
+    },
+    ...over,
+  };
+}
+
+export function makeSkill(over: Partial<SkillFile> = {}): SkillFile {
+  return {
+    version: '1.0',
+    domain: 'example.com',
+    capturedAt: '2026-07-01T00:00:00.000Z',
+    baseUrl: 'https://example.com',
+    endpoints: [makeEndpoint()],
+    metadata: { captureCount: 1, filteredCount: 0, toolVersion: 'test' },
+    provenance: 'self',
+    ...over,
+  };
+}

--- a/test/doctor/load.test.ts
+++ b/test/doctor/load.test.ts
@@ -1,0 +1,82 @@
+// test/doctor/load.test.ts
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { loadSkillsForDoctor } from '../../src/doctor/index.js';
+import { signatureFindings } from '../../src/doctor/checks/invalid-signature.js';
+import { signSkillFileAs } from '../../src/skill/signing.js';
+import { makeSkill } from './fixtures.js';
+
+const NOW = new Date('2026-07-19T00:00:00.000Z');
+
+describe('loadSkillsForDoctor', () => {
+  let dir: string;
+  const key = randomBytes(32);
+
+  before(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'doctor-load-'));
+    // valid signed file
+    const good = signSkillFileAs(makeSkill({ domain: 'good.com', baseUrl: 'https://good.com' }), key, 'self');
+    await writeFile(join(dir, 'good.com.json'), JSON.stringify(good));
+    // unsigned file
+    await writeFile(join(dir, 'unsigned.com.json'),
+      JSON.stringify(makeSkill({ domain: 'unsigned.com', baseUrl: 'https://unsigned.com' })));
+    // tampered file: signed, then endpoint list mutated
+    const tampered = signSkillFileAs(makeSkill({ domain: 'bad.com', baseUrl: 'https://bad.com' }), key, 'self');
+    (tampered as any).endpoints = [];
+    await writeFile(join(dir, 'bad.com.json'), JSON.stringify(tampered));
+    // expired: valid signature but signedAt 200 days before NOW
+    const old = signSkillFileAs(makeSkill({ domain: 'old.com', baseUrl: 'https://old.com' }), key, 'self');
+    // re-sign date is now; fake age by rewriting signedAt AFTER signing breaks the HMAC,
+    // so instead treat "expired" as: valid HMAC + old signedAt. We simulate by signing
+    // with a monkeypatched clock is overkill — loader computes age from signedAt, and
+    // signedAt is covered by the HMAC, so build it via signSkillFileAs and then
+    // verify the loader's age logic with an injected `now` far in the future.
+    await writeFile(join(dir, 'old.com.json'), JSON.stringify(old));
+    // garbage file
+    await writeFile(join(dir, 'broken.com.json'), '{ not json');
+    // subdirectory must be ignored
+    await mkdir(join(dir, '.quarantine'), { recursive: true });
+    await writeFile(join(dir, '.quarantine', 'gone.com.json'), JSON.stringify(makeSkill()));
+    // non-json ignored
+    await writeFile(join(dir, 'index.bin'), 'x');
+  });
+
+  after(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it('enumerates only top-level *.json and classifies signature status', async () => {
+    const loaded = await loadSkillsForDoctor(dir, key, NOW);
+    const byDomain = Object.fromEntries(loaded.map(l => [l.domain, l]));
+    assert.equal(loaded.length, 5); // good, unsigned, bad, old, broken — not .quarantine, not index.bin
+    assert.equal(byDomain['good.com'].signatureStatus, 'valid');
+    assert.equal(byDomain['unsigned.com'].signatureStatus, 'unsigned');
+    assert.equal(byDomain['bad.com'].signatureStatus, 'mismatch');
+    assert.equal(byDomain['broken.com'].signatureStatus, 'invalid-file');
+    assert.equal(byDomain['broken.com'].skill, null);
+    assert.ok(byDomain['broken.com'].loadError);
+  });
+
+  it('marks valid-but-old signatures expired using injected now', async () => {
+    const future = new Date('2027-06-01T00:00:00.000Z'); // >180d after signing
+    const loaded = await loadSkillsForDoctor(dir, key, future);
+    const old = loaded.find(l => l.domain === 'old.com')!;
+    assert.equal(old.signatureStatus, 'expired');
+  });
+});
+
+describe('signatureFindings', () => {
+  it('maps non-valid statuses to warn findings and valid to none', () => {
+    const base = { domain: 'x.com', filePath: '/x', skill: null };
+    assert.equal(signatureFindings({ ...base, skill: makeSkill(), signatureStatus: 'valid' }).length, 0);
+    for (const status of ['unsigned', 'mismatch', 'expired', 'invalid-file'] as const) {
+      const f = signatureFindings({ ...base, signatureStatus: status, loadError: 'boom' });
+      assert.equal(f.length, 1);
+      assert.equal(f[0].checkId, 'invalid-signature');
+      assert.equal(f[0].severity, 'warn');
+      assert.equal(f[0].fixable, false);
+    }
+  });
+});

--- a/test/doctor/snapshot.test.ts
+++ b/test/doctor/snapshot.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdtemp, writeFile, readFile, rm, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  snapshotOnce, quarantineSkill, restoreSkill, quarantinePath, snapshotPath,
+} from '../../src/doctor/snapshot.js';
+
+async function exists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+describe('doctor snapshot/quarantine/restore', () => {
+  let dir: string;
+  const live = () => join(dir, 'a.com.json');
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'doctor-snap-'));
+    await writeFile(live(), '{"original":true}\n');
+  });
+  afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it('snapshotOnce copies only on first touch', async () => {
+    assert.equal(await snapshotOnce(dir, 'a.com'), true);
+    await writeFile(live(), '{"edited":1}\n');
+    assert.equal(await snapshotOnce(dir, 'a.com'), false); // second touch: no-op
+    assert.equal(await readFile(snapshotPath(dir, 'a.com'), 'utf-8'), '{"original":true}\n');
+  });
+
+  it('quarantine moves the file; restore brings it back when no live file', async () => {
+    await quarantineSkill(dir, 'a.com');
+    assert.equal(await exists(live()), false);
+    assert.equal(await exists(quarantinePath(dir, 'a.com')), true);
+    assert.equal(await restoreSkill(dir, 'a.com'), 'quarantine');
+    assert.equal(await readFile(live(), 'utf-8'), '{"original":true}\n');
+  });
+
+  it('quarantine restore REFUSES when a live file exists (re-captured)', async () => {
+    await quarantineSkill(dir, 'a.com');
+    await writeFile(live(), '{"recaptured":true}\n');
+    await assert.rejects(() => restoreSkill(dir, 'a.com'), /refusing/i);
+    assert.equal(await readFile(live(), 'utf-8'), '{"recaptured":true}\n'); // untouched
+  });
+
+  it('.orig beats quarantine and restores bytes-identical over a live file', async () => {
+    await snapshotOnce(dir, 'a.com');
+    await writeFile(live(), '{"edited":1}\n');
+    await quarantineSkill(dir, 'a.com');          // both .orig and quarantine now exist
+    await writeFile(live(), '{"recaptured":true}\n');
+    assert.equal(await restoreSkill(dir, 'a.com'), 'orig');
+    assert.equal(await readFile(live(), 'utf-8'), '{"original":true}\n');
+  });
+
+  it('restore with nothing to restore throws', async () => {
+    await assert.rejects(() => restoreSkill(dir, 'nothing.com'), /nothing to restore/i);
+  });
+});

--- a/test/doctor/snapshot.test.ts
+++ b/test/doctor/snapshot.test.ts
@@ -55,4 +55,27 @@ describe('doctor snapshot/quarantine/restore', () => {
   it('restore with nothing to restore throws', async () => {
     await assert.rejects(() => restoreSkill(dir, 'nothing.com'), /nothing to restore/i);
   });
+
+  it('restore rejects a path-traversal domain', async () => {
+    await assert.rejects(() => restoreSkill(dir, '../evil'), /Invalid domain/);
+  });
+
+  it('quarantining the same domain twice never clobbers the first copy', async () => {
+    await quarantineSkill(dir, 'a.com');
+    assert.equal(await readFile(quarantinePath(dir, 'a.com'), 'utf-8'), '{"original":true}\n');
+
+    await writeFile(live(), '{"recaptured":true}\n'); // recreate live file
+    await quarantineSkill(dir, 'a.com');
+
+    // unsuffixed copy untouched; a timestamped sibling holds the second one
+    assert.equal(await readFile(quarantinePath(dir, 'a.com'), 'utf-8'), '{"original":true}\n');
+    const { readdir } = await import('node:fs/promises');
+    const entries = await readdir(join(dir, '.quarantine'));
+    const timestamped = entries.filter(e => e !== 'a.com.json' && e.startsWith('a.com.') && e.endsWith('.json'));
+    assert.equal(timestamped.length, 1);
+    assert.equal(
+      await readFile(join(dir, '.quarantine', timestamped[0]), 'utf-8'),
+      '{"recaptured":true}\n',
+    );
+  });
 });


### PR DESCRIPTION
## What

`apitap doctor` — offline hygiene lint for the skill store, with a conservative `--fix`.

Dogfooding (2026-07-19) showed the store rots silently: skills captured for WAF-captcha/ad hosts, tracker beacon endpoints inside good skills, an endpoint duplicated across 3 paths, 4-month-old captures with no staleness signal, and 43 never-verified endpoints ranking as `tier:unknown`.

```
apitap doctor              # scan, report, exit 1 on findings
apitap doctor --fix        # apply conservative fixes (quarantine + snapshot, restorable)
apitap doctor --restore <domain>
apitap doctor --json
```

## Architecture

```mermaid
flowchart LR
    subgraph store["~/.apitap/skills/"]
        files["*.json (readdir, not index)"]
        Q[".quarantine/"]
        O[".doctor/*.orig"]
    end
    files --> loader["soft loader\nparse + validate + soft sig verify"]
    loader --> checks["7 pure checks\njunk-domain / beacon / dupes /\nempty / stale / unverified / unparameterized"]
    checks --> engine["runDoctor engine"]
    engine -->|"quarantine (rename, never rm)"| Q
    engine -->|"first-touch snapshot"| O
    engine -->|"edit + re-sign\n(only if signature valid)"| files
    engine --> report["DoctorReport → CLI / --json"]
```

## Safety model

- **Nothing destroyed**: whole files move to `.quarantine/` (non-clobbering, timestamped on collision); endpoint edits snapshot the original once to `.doctor/`; `--restore` undoes either; no `rm`/`unlink` anywhere.
- **Integrity gate**: edit fixes are refused on files whose HMAC doesn't verify or whose basename ≠ `skill.domain` — editing + re-signing unverified content would launder tampering. Re-sign only via `signSkillFileAs` + `provenanceForSigning`.
- **Conservative classifiers**: beacon strip needs tracker-path AND contentless-response signals; dedupe auto-drops only strictly dominated duplicates; everything else is report-only.
- Domain strings validated (store.ts regex + `..` rejection) before any path join.

## Out of scope (deliberate)

Live re-verification (`--live`) belongs to the verifier workstream; no MCP exposure (doctor is shell maintenance).

## Testing

1,678 tests green (44 new across checks/snapshot/engine/CLI, including negative conservatism cases and tamper/traversal/clobber scenarios). Reviewed by whole-branch pass + external T2 security pass; all findings fixed or explicitly accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MNoD29QgKynL4uDXrCRdj
