### PR TITLE
Agent-trust honesty: replay example-param seeding + peek transport-error signals

### DIFF
--- a/src/discovery/fetch.ts
+++ b/src/discovery/fetch.ts
@@ -22,6 +22,21 @@ const DEFAULT_TIMEOUT = 5000;
 const DEFAULT_MAX_BODY = 512 * 1024; // 512KB
 const USER_AGENT = 'ApiTap-Discovery/1.0';
 
+/** Why a safeFetch attempt produced no result. */
+export interface SafeFetchFailure {
+  /** 'ssrf' = blocked by our own SSRF policy; 'transport' = client/network failure. */
+  kind: 'ssrf' | 'transport';
+  /** Error code when available (ECONNREFUSED, UND_ERR_HEADERS_OVERFLOW, TIMEOUT, …). */
+  code: string;
+  message: string;
+}
+
+export interface SafeFetchDetailedResult {
+  result: FetchResult | null;
+  /** Set exactly when result is null. */
+  error: SafeFetchFailure | null;
+}
+
 /**
  * Fetch a URL with SSRF protection, timeout, and size limits.
  * Returns null on any failure (network error, SSRF blocked, timeout).
@@ -30,20 +45,33 @@ export async function safeFetch(
   url: string,
   options: SafeFetchOptions = {},
 ): Promise<FetchResult | null> {
+  return (await safeFetchDetailed(url, options)).result;
+}
+
+/**
+ * Like safeFetch, but preserves WHY a fetch failed so callers (peek) can
+ * distinguish "the site blocked us" from "our client choked" (e.g. undici
+ * headers overflow on huge CSP headers, where curl gets a 200).
+ */
+export async function safeFetchDetailed(
+  url: string,
+  options: SafeFetchOptions = {},
+): Promise<SafeFetchDetailedResult> {
   // M18: Use DNS-resolving SSRF check to prevent rebinding attacks
   if (!options.skipSsrf) {
     const ssrfResult = await resolveAndValidateUrl(url);
-    if (!ssrfResult.safe) return null;
+    if (!ssrfResult.safe) {
+      return { result: null, error: { kind: 'ssrf', code: 'SSRF_BLOCKED', message: ssrfResult.reason ?? 'blocked by SSRF policy' } };
+    }
   }
 
   const timeout = options.timeout ?? DEFAULT_TIMEOUT;
   const method = options.method ?? 'GET';
   const maxBody = options.maxBodySize ?? DEFAULT_MAX_BODY;
 
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeout);
-
     const response = await fetch(url, {
       method,
       signal: controller.signal,
@@ -55,17 +83,19 @@ export async function safeFetch(
       redirect: 'manual',
     });
 
-    clearTimeout(timer);
-
     // SSRF-safe manual redirect (one hop max, with DNS resolution check)
     if (response.status >= 300 && response.status < 400 && response.headers.has('location')) {
       const location = response.headers.get('location');
-      if (!location) return null;
+      if (!location) {
+        return { result: null, error: { kind: 'transport', code: 'BAD_REDIRECT', message: 'redirect without location header' } };
+      }
       const redirectUrl = new URL(location, url).toString();
       const ssrfResult = await resolveAndValidateUrl(redirectUrl);
-      if (!ssrfResult.safe) return null;
+      if (!ssrfResult.safe) {
+        return { result: null, error: { kind: 'ssrf', code: 'SSRF_BLOCKED', message: ssrfResult.reason ?? 'redirect blocked by SSRF policy' } };
+      }
       // Follow one redirect hop only
-      return await safeFetch(redirectUrl, { ...options, skipSsrf: true });
+      return await safeFetchDetailed(redirectUrl, { ...options, skipSsrf: true });
     }
 
     // Extract headers
@@ -78,16 +108,47 @@ export async function safeFetch(
 
     // For HEAD requests, don't read body
     if (method === 'HEAD') {
-      return { status: response.status, headers, body: '', contentType };
+      return { result: { status: response.status, headers, body: '', contentType }, error: null };
     }
 
     // Read body with size limit
     const body = await readBodyLimited(response, maxBody);
 
-    return { status: response.status, headers, body, contentType };
-  } catch {
-    return null;
+    return { result: { status: response.status, headers, body, contentType }, error: null };
+  } catch (err) {
+    return { result: null, error: describeFetchError(err) };
+  } finally {
+    clearTimeout(timer);
   }
+}
+
+function describeFetchError(err: unknown): SafeFetchFailure {
+  if (err instanceof Error) {
+    if (err.name === 'AbortError' || err.name === 'TimeoutError') {
+      return { kind: 'transport', code: 'TIMEOUT', message: 'request timed out' };
+    }
+    // fetch wraps the real failure in TypeError('fetch failed') with .cause
+    const cause = (err as { cause?: unknown }).cause;
+    const code = extractErrorCode(cause) ?? extractErrorCode(err);
+    const message = cause instanceof Error && cause.message ? cause.message : err.message;
+    return { kind: 'transport', code: code ?? err.name, message };
+  }
+  return { kind: 'transport', code: 'UNKNOWN', message: String(err) };
+}
+
+function extractErrorCode(err: unknown): string | null {
+  if (!err || typeof err !== 'object') return null;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === 'string' && code) return code;
+  // AggregateError (e.g. dual-stack connect failures): first coded sub-error
+  const errors = (err as { errors?: unknown[] }).errors;
+  if (Array.isArray(errors)) {
+    for (const sub of errors) {
+      const subCode = extractErrorCode(sub);
+      if (subCode) return subCode;
+    }
+  }
+  return null;
 }
 
 async function readBodyLimited(response: Response, maxSize: number): Promise<string> {

--- a/src/read/peek.ts
+++ b/src/read/peek.ts
@@ -1,6 +1,6 @@
 // src/read/peek.ts
 import type { PeekResult } from './types.js';
-import { safeFetch } from '../discovery/fetch.js';
+import { safeFetchDetailed, type SafeFetchFailure } from '../discovery/fetch.js';
 import { assertSsrfBypassAllowed } from '../skill/ssrf.js';
 
 export interface PeekOptions {
@@ -16,21 +16,35 @@ export async function peek(url: string, options: PeekOptions = {}): Promise<Peek
   const signals: string[] = [];
 
   // Try HEAD first
-  let result = await safeFetch(url, {
+  const headAttempt = await safeFetchDetailed(url, {
     method: 'HEAD',
     skipSsrf: options.skipSsrf,
   });
+  let result = headAttempt.result;
+  let fetchError: SafeFetchFailure | null = headAttempt.error;
 
   // Fall back to GET if HEAD fails (null = network/SSRF error)
   if (!result) {
-    result = await safeFetch(url, {
+    const getAttempt = await safeFetchDetailed(url, {
       method: 'GET',
       skipSsrf: options.skipSsrf,
     });
+    result = getAttempt.result;
+    if (!result) fetchError = getAttempt.error ?? fetchError;
   }
 
-  // Both HEAD and GET failed
+  // Both HEAD and GET failed — say why, honestly. A client-side transport
+  // failure is NOT the site blocking us (Polymarket's huge CSP headers
+  // overflow undici while curl gets a 200).
   if (!result) {
+    if (fetchError?.kind === 'ssrf') {
+      signals.push(`blocked by SSRF protection: ${fetchError.message}`);
+    } else {
+      signals.push(`transport error: ${fetchError?.code ?? 'UNKNOWN'} (${fetchError?.message ?? 'fetch failed'})`);
+      if (fetchError?.code === 'UND_ERR_HEADERS_OVERFLOW') {
+        signals.push('response headers exceeded the HTTP client limit — not bot protection; the site may still be reachable');
+      }
+    }
     return {
       url,
       status: 0,
@@ -39,8 +53,8 @@ export async function peek(url: string, options: PeekOptions = {}): Promise<Peek
       server: null,
       framework: null,
       botProtection: null,
-      signals: ['fetch failed'],
-      recommendation: 'blocked',
+      signals,
+      recommendation: fetchError?.kind === 'ssrf' ? 'blocked' : 'error',
     };
   }
 

--- a/src/read/types.ts
+++ b/src/read/types.ts
@@ -10,7 +10,8 @@ export interface PeekResult {
   framework: string | null;
   botProtection: string | null;
   signals: string[];
-  recommendation: 'read' | 'capture' | 'auth_required' | 'blocked';
+  /** 'error' = client-side transport failure (timeout, headers overflow) — the site did NOT block us. */
+  recommendation: 'read' | 'capture' | 'auth_required' | 'blocked' | 'error';
 }
 
 export interface ReadResult {

--- a/src/replay/engine.ts
+++ b/src/replay/engine.ts
@@ -331,6 +331,19 @@ export async function replayEndpoint(
 
   const url = new URL(resolvedPath, skill.baseUrl);
 
+  // When the skill carries no queryParams but the captured example URL does,
+  // seed from the example — otherwise the request goes out bare and APIs like
+  // open-meteo answer 200 with an empty body (silent false success).
+  if (Object.keys(endpoint.queryParams).length === 0) {
+    try {
+      for (const [key, val] of new URL(endpoint.examples.request.url).searchParams) {
+        url.searchParams.set(key, val);
+      }
+    } catch {
+      // Invalid example URL — nothing to seed
+    }
+  }
+
   // Apply query params: start with captured defaults, override with provided params
   for (const [key, val] of Object.entries(endpoint.queryParams)) {
     if (shouldOmitQueryParam(val)) continue;

--- a/test/read/peek.test.ts
+++ b/test/read/peek.test.ts
@@ -214,11 +214,42 @@ describe('peek', () => {
     assert.equal(challenged.botProtection, 'cloudflare');
   });
 
-  it('SSRF blocked URL returns blocked with fetch failed signal', async () => {
+  it('SSRF blocked URL returns blocked with an SSRF signal, not a generic fetch failure', async () => {
     // Without skipSsrf, localhost is blocked by SSRF protection
     const result = await peek('http://127.0.0.1:9999');
     assert.equal(result.accessible, false);
     assert.equal(result.recommendation, 'blocked');
-    assert.ok(result.signals.includes('fetch failed'));
+    assert.ok(result.signals.some(s => /ssrf/i.test(s)), `signals: ${result.signals}`);
+  });
+
+  it('connection-refused is reported as a transport error, not "blocked"', async () => {
+    // Nothing listens on this port — a client-side transport failure must not
+    // be mislabeled as the site blocking us.
+    await teardownServer();
+    const deadUrl = baseUrl; // server just closed, port now refuses
+    const result = await peek(deadUrl, { skipSsrf: true });
+    assert.equal(result.status, 0);
+    assert.equal(result.accessible, false);
+    assert.equal(result.recommendation, 'error');
+    assert.ok(result.signals.some(s => s.includes('ECONNREFUSED')), `signals: ${result.signals}`);
+    await setupServer(); // restore for afterEach teardown
+  });
+
+  it('oversized response headers surface UND_ERR_HEADERS_OVERFLOW, not "blocked"', async () => {
+    // Polymarket class: enormous CSP headers overflow undici's client-side
+    // header limit. curl gets a 200 — this is not bot protection.
+    responseHeaders['content-security-policy'] = 'x'.repeat(128 * 1024);
+    const result = await peek(baseUrl, { skipSsrf: true });
+    assert.equal(result.status, 0);
+    assert.equal(result.accessible, false);
+    assert.equal(result.recommendation, 'error');
+    assert.ok(
+      result.signals.some(s => s.includes('UND_ERR_HEADERS_OVERFLOW')),
+      `signals: ${result.signals}`,
+    );
+    assert.ok(
+      result.signals.some(s => /not bot protection/i.test(s)),
+      `signals: ${result.signals}`,
+    );
   });
 });

--- a/test/replay/engine.test.ts
+++ b/test/replay/engine.test.ts
@@ -29,6 +29,12 @@ describe('replayEndpoint', () => {
       } else if (req.url === '/api/item/99') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ id: 99, name: 'Dynamic' }));
+      } else if (req.url?.startsWith('/api/echo-query')) {
+        // Echoes query params back — and like open-meteo, returns an empty
+        // body on 200 when called with no query at all.
+        const query = Object.fromEntries(new URL(req.url, 'http://x').searchParams);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(Object.keys(query).length === 0 ? '' : JSON.stringify({ query }));
       } else if (req.url === '/api/empty-json') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end('');
@@ -167,6 +173,78 @@ describe('replayEndpoint', () => {
     const result = await replayEndpoint(skill, 'get-api-item', { _skipSsrfCheck: true });
     assert.equal(result.status, 200);
     assert.deepEqual(result.data, { id: 42, name: 'Special' });
+  });
+
+  it('seeds query params from the example URL when queryParams is empty', async () => {
+    // open-meteo class skill rot: queryParams {} but the example URL carries
+    // the required query string. Without seeding, the call goes out bare and
+    // the API returns an empty 200 — a silent false success.
+    const skill = makeSkill();
+    skill.endpoints.push({
+      id: 'get-forecast',
+      method: 'GET',
+      path: '/api/echo-query',
+      queryParams: {},
+      headers: {},
+      responseShape: { type: 'object' },
+      examples: {
+        request: { url: `${baseUrl}/api/echo-query?latitude=52.52&longitude=13.41&current=temperature_2m`, headers: {} },
+        responsePreview: null,
+      },
+    });
+
+    const result = await replayEndpoint(skill, 'get-forecast', { _skipSsrfCheck: true });
+    assert.equal(result.status, 200);
+    assert.deepEqual(result.data, {
+      query: { latitude: '52.52', longitude: '13.41', current: 'temperature_2m' },
+    });
+  });
+
+  it('explicit params override example-seeded query params', async () => {
+    const skill = makeSkill();
+    skill.endpoints.push({
+      id: 'get-forecast',
+      method: 'GET',
+      path: '/api/echo-query',
+      queryParams: {},
+      headers: {},
+      responseShape: { type: 'object' },
+      examples: {
+        request: { url: `${baseUrl}/api/echo-query?latitude=52.52&longitude=13.41`, headers: {} },
+        responsePreview: null,
+      },
+    });
+
+    const result = await replayEndpoint(skill, 'get-forecast', {
+      params: { latitude: '48.85', longitude: '2.35' },
+      _skipSsrfCheck: true,
+    });
+    assert.equal(result.status, 200);
+    assert.deepEqual(result.data, {
+      query: { latitude: '48.85', longitude: '2.35' },
+    });
+  });
+
+  it('does not seed from example URL when queryParams is populated', async () => {
+    // When the skill has real queryParams, those stay authoritative — extra
+    // junk in the example query string (trackers etc.) must not leak in.
+    const skill = makeSkill();
+    skill.endpoints.push({
+      id: 'get-echo',
+      method: 'GET',
+      path: '/api/echo-query',
+      queryParams: { limit: { type: 'string', example: '10' } },
+      headers: {},
+      responseShape: { type: 'object' },
+      examples: {
+        request: { url: `${baseUrl}/api/echo-query?limit=10&utm_source=tracker`, headers: {} },
+        responsePreview: null,
+      },
+    });
+
+    const result = await replayEndpoint(skill, 'get-echo', { _skipSsrfCheck: true });
+    assert.equal(result.status, 200);
+    assert.deepEqual(result.data, { query: { limit: '10' } });
   });
 
   it('returns structured truncation metadata when maxBytes cuts the response', async () => {


### PR DESCRIPTION
## Summary

Fixes the two highest-severity agent-trust failures from the 2026-07-19 wild dogfood gauntlet (`docs/testing/2026-07-19-wild-gauntlet.md`, internal):

### 1. Replay: silent empty success when `queryParams` is empty (P0)

`replayEndpoint` built the query solely from `endpoint.queryParams`. For skills where that map is empty but `examples.request.url` carries the real query string (open-meteo), the request went out with **no query at all** — the API answered `200` with an empty body and the agent saw a green success with `data: ""`.

Now: when `queryParams` is `{}`, the query is seeded from the captured example URL. Explicit `params` still override the seed, and populated `queryParams` remain authoritative (example-URL tracker junk cannot leak in).

Verified in the wild: `apitap replay api.open-meteo.com get-forecast --json` now returns actual weather data.

### 2. Peek: transport failures mislabeled as "blocked" (P1)

`safeFetch` returned `null` on any failure, so `peek` collapsed everything into `signals: ["fetch failed"], recommendation: "blocked"`. Polymarket's enormous CSP headers overflow undici's header limit (`UND_ERR_HEADERS_OVERFLOW`) while `curl` gets a 200 — that is a client limitation, not bot protection.

Now:
- new `safeFetchDetailed` preserves the failure (`kind: 'ssrf' | 'transport'`, `code`, `message`); `safeFetch` is a thin wrapper, no call-site churn
- `peek` emits a new `recommendation: 'error'` for transport failures, with the real code in `signals`
- `UND_ERR_HEADERS_OVERFLOW` gets an explicit "not bot protection" note
- SSRF-blocked URLs now say "blocked by SSRF protection: <reason>" instead of "fetch failed"

Verified in the wild: `apitap peek https://polymarket.com --json` now reports the headers overflow honestly.

## Test plan

- [x] New tests written first and watched fail (TDD): example-URL seeding, explicit-param override, no-seed-when-populated; ECONNREFUSED → transport error, oversized headers → `UND_ERR_HEADERS_OVERFLOW`, SSRF signal
- [x] Full suite: 1683/1683 pass, `npm run typecheck` clean
- [x] Live verification of both gauntlet repro commands from source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7nDVVCHyQfffUNB31LSkS