### PR TITLE
read: label bot-challenge interstitials (Reddit verification) instead of empty success

### DIFF
--- a/src/read/challenge.ts
+++ b/src/read/challenge.ts
@@ -1,0 +1,35 @@
+// src/read/challenge.ts
+//
+// Bot-challenge / interstitial detection for the generic read pipeline.
+// Sites like Reddit and Cloudflare-fronted pages answer HTTP 200 with a
+// human-verification page instead of content. Without detection, read
+// reports a green success with empty content — a silent trust failure.
+//
+// Detection is deliberately title-driven (plus unambiguous vendor markers
+// in the HTML) so an article ABOUT captchas never trips it.
+
+const TITLE_PATTERNS: Array<{ pattern: RegExp; vendor: string }> = [
+  { pattern: /just a moment/i, vendor: 'cloudflare' },
+  { pattern: /attention required!?\s*\|\s*cloudflare/i, vendor: 'cloudflare' },
+  { pattern: /ddos-guard/i, vendor: 'ddos-guard' },
+  { pattern: /please wait.{0,40}verification|verification.{0,40}please wait/i, vendor: 'challenge' },
+  { pattern: /checking your browser/i, vendor: 'challenge' },
+  { pattern: /verify(?:ing)? you are (?:a )?human/i, vendor: 'challenge' },
+  { pattern: /enable javascript and cookies to continue/i, vendor: 'challenge' },
+];
+
+/**
+ * Returns the challenge vendor ('cloudflare', 'ddos-guard', or generic
+ * 'challenge') when the page is a bot-verification interstitial, else null.
+ */
+export function detectChallengePage(html: string, title: string | null): string | null {
+  if (title) {
+    for (const { pattern, vendor } of TITLE_PATTERNS) {
+      if (pattern.test(title)) return vendor;
+    }
+  }
+  // Cloudflare's challenge orchestration script path is unique to real
+  // challenge pages — never present on ordinary CF-fronted content.
+  if (html.includes('/cdn-cgi/challenge-platform/')) return 'cloudflare';
+  return null;
+}

--- a/src/read/index.ts
+++ b/src/read/index.ts
@@ -7,6 +7,7 @@ import type { ReadResult } from './types.js';
 import { safeFetch } from '../discovery/fetch.js';
 import { findDecoder } from './decoders/index.js';
 import { parseHead, extractContent } from './extract.js';
+import { detectChallengePage } from './challenge.js';
 import { scanRawHtml } from './scan.js';
 import { appendFinding } from '../trapaware/audit.js';
 import { assertSsrfBypassAllowed } from '../skill/ssrf.js';
@@ -108,9 +109,16 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
   const head = parseHead(html);
   const body = extractContent(html);
 
+  // Bot-challenge interstitial (Reddit "please wait for verification",
+  // Cloudflare "Just a moment…"): a 200 whose body is a verification page,
+  // not content. Label it honestly instead of returning an empty success.
+  const challenge = detectChallengePage(html, head.ogTitle || head.title || null);
+
   // Determine source
   let source: string;
-  if (body.isSpaShell) {
+  if (challenge) {
+    source = 'challenge-page';
+  } else if (body.isSpaShell) {
     source = 'spa-shell';
   } else if (body.content.trim().length === 0) {
     source = 'og-tags-only';
@@ -127,6 +135,11 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
 
   const title = head.ogTitle || head.title || null;
 
+  // Never hand back an empty success for a challenge page — say what happened.
+  if (challenge && content.trim().length === 0) {
+    content = `[bot-challenge interstitial (${challenge}): the site withheld content pending human verification — no real page content was served]`;
+  }
+
   const legacy = !scanEnabled;
 
   if (legacy) {
@@ -138,6 +151,7 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
       content,
       links: body.links,
       images: body.images,
+      ...(challenge ? { botProtection: challenge } : {}),
       metadata: {
         type: head.ogType || 'unknown',
         publishedAt: head.publishedTime || null,
@@ -167,6 +181,7 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
     images,
     ...(imagesOmitted > 0 ? { imagesOmitted } : {}),
     ...(contentTruncated ? { contentTruncated: true } : {}),
+    ...(challenge ? { botProtection: challenge } : {}),
     metadata: {
       type: head.ogType || 'unknown',
       publishedAt: head.publishedTime || null,

--- a/src/read/types.ts
+++ b/src/read/types.ts
@@ -28,6 +28,10 @@ export interface ReadResult {
   imagesOmitted?: number;
   /** True when content was cut to fit maxBytes. Absent on the legacy path. */
   contentTruncated?: boolean;
+  /** Set when the page is a bot-challenge interstitial ('cloudflare',
+   *  'ddos-guard', or generic 'challenge') — the site withheld real content.
+   *  metadata.source is 'challenge-page' in that case. */
+  botProtection?: string;
   metadata: {
     type: string;
     publishedAt: string | null;

--- a/test/read/read.test.ts
+++ b/test/read/read.test.ts
@@ -127,4 +127,54 @@ describe('read', () => {
     const result = await read(baseUrl, { skipSsrf: true });
     assert.equal(result, null);
   });
+
+  it('labels a Reddit-style verification interstitial instead of claiming empty success', async () => {
+    // Real shape of Reddit's challenge page: challenge title + auto-submit
+    // "solution" form, zero article content, served with HTTP 200.
+    routes['/'] = {
+      status: 200,
+      contentType: 'text/html',
+      body: `<html><head><title>Reddit - Please wait for verification</title>
+        <script>document.addEventListener("DOMContentLoaded",async function(){var e=document.forms[0];e.elements.namedItem("solution").value="x";e.requestSubmit()});</script>
+        </head><body><main><form method="post"><input type="hidden" name="solution"></form></main></body></html>`,
+    };
+
+    const result = await read(baseUrl, { skipSsrf: true });
+    assert.ok(result);
+    assert.equal(result.botProtection, 'challenge');
+    assert.equal(result.metadata.source, 'challenge-page');
+    assert.ok(result.content.length > 0, 'content must not be silently empty');
+    assert.ok(/challenge|verification/i.test(result.content), `content: ${result.content}`);
+  });
+
+  it('labels a Cloudflare "Just a moment" challenge as botProtection=cloudflare', async () => {
+    routes['/'] = {
+      status: 200,
+      contentType: 'text/html',
+      body: `<html><head><title>Just a moment...</title></head>
+        <body><script src="/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1"></script>
+        <p>Verifying you are human. This may take a few seconds.</p></body></html>`,
+    };
+
+    const result = await read(baseUrl, { skipSsrf: true });
+    assert.ok(result);
+    assert.equal(result.botProtection, 'cloudflare');
+    assert.equal(result.metadata.source, 'challenge-page');
+  });
+
+  it('does not flag an article that merely talks about human verification', async () => {
+    routes['/'] = {
+      status: 200,
+      contentType: 'text/html',
+      body: `<html><head><title>How CAPTCHAs work</title></head><body><article>
+        <p>Sites often ask you to verify you are human. Checking your browser
+        for automation markers is a common technique used by bot walls.</p>
+        </article></body></html>`,
+    };
+
+    const result = await read(baseUrl, { skipSsrf: true });
+    assert.ok(result);
+    assert.equal(result.botProtection, undefined);
+    assert.equal(result.metadata.source, 'readability');
+  });
 });


### PR DESCRIPTION
## Summary

Closes the last agent-trust honesty gap from the 2026-07-19 wild dogfood gauntlet: `apitap read https://www.reddit.com/r/programming/` returned `title: "Reddit - Please wait for verification", content: "", findings: []` — a green empty success for a bot wall.

- New `src/read/challenge.ts`: detects bot-challenge interstitials. Detection is deliberately **title-driven** (Reddit's verification title, Cloudflare's "Just a moment…" / "Attention Required", DDoS-Guard, "checking your browser", "verify you are human") plus one unambiguous HTML marker (`/cdn-cgi/challenge-platform/`), so a page that merely *talks about* captchas never trips it.
- `ReadResult` gains optional `botProtection` (`'cloudflare' | 'ddos-guard' | 'challenge'`), mirroring the field name peek already uses.
- `metadata.source` becomes `'challenge-page'` (takes precedence over spa-shell/og-tags-only).
- When extraction yields nothing, `content` carries an explicit note (`[bot-challenge interstitial (…): the site withheld content pending human verification …]`) instead of `""` — so agents that only look at `content` still see the truth. Real extracted text, when present, is left untouched.
- Applied on both the standard and legacy (`scan: false`) paths — the silent lie shouldn't survive under either envelope.

Peek's `accessible: true, botProtection: null` for Reddit is inherent to HEAD-only triage (the challenge is body-level) and is not changed here; read is where the honest signal belongs.

## Live verification (from source)

`apitap read https://www.reddit.com/r/programming/ --json` now returns `botProtection: "challenge"`, `metadata.source: "challenge-page"`, and the explicit interstitial note as content.

## Test plan

- [x] TDD: three new tests written first and watched fail — Reddit-style interstitial labeled, Cloudflare challenge labeled `cloudflare`, and a false-positive guard (article about captchas stays `readability`)
- [x] Full suite 1686/1686 pass, `npm run typecheck` clean
- [x] Live Reddit repro verified fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7nDVVCHyQfffUNB31LSkS