### PR TITLE
doctor UX: summary-first default + --help fix

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ import { searchSwaggerHub, fetchSwaggerHubSpec } from './skill/swaggerhub.js';
 import { buildIndex, removeFromIndex } from './skill/index.js';
 import { runDoctor } from './doctor/index.js';
 import { restoreSkill } from './doctor/snapshot.js';
-import { formatDoctorReport } from './doctor/format.js';
+import { formatDoctorReport, formatDoctorSummary } from './doctor/format.js';
 import {
   resolveGitHubToken,
   searchOrgSpecs,
@@ -120,6 +120,7 @@ function printUsage(): void {
     apitap doctor [domain]     Skill-store hygiene: report junk/dupes/stale (offline)
       --fix                    Apply conservative fixes (quarantine + snapshot, restorable)
       --restore <domain>       Undo a doctor fix or quarantine
+      --verbose                Full per-finding line output (default is a summary)
       --stale-days <n>         Staleness threshold (default 90)
     apitap stats               Show token savings report
     apitap index build         Rebuild search index (run after manual edits)
@@ -2561,6 +2562,11 @@ async function handleDoctor(positional: string[], flags: Record<string, string |
       jsonFlag = true;
       if (domain === undefined) domain = flags.json;
     }
+    let verboseFlag = flags.verbose === true;
+    if (typeof flags.verbose === 'string') {
+      verboseFlag = true;
+      if (domain === undefined) domain = flags.verbose;
+    }
     const report = await runDoctor({
       skillsDir, signingKey,
       fix: fixFlag,
@@ -2570,7 +2576,8 @@ async function handleDoctor(positional: string[], flags: Record<string, string |
     if (jsonFlag) {
       console.log(JSON.stringify(report, null, 2));
     } else {
-      console.log(formatDoctorReport(report, fixFlag));
+      const fullDetail = verboseFlag || domain !== undefined;
+      console.log(fullDetail ? formatDoctorReport(report, fixFlag) : formatDoctorSummary(report, fixFlag));
       // Auth orphan info for quarantined domains (report-only; quarantine
       // deliberately does not touch auth.enc, unlike forget)
       for (const domain of report.quarantined) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -188,6 +188,21 @@ function printUsage(): void {
   `.trim());
 }
 
+const DOCTOR_USAGE = `
+  Usage: apitap doctor [domain] [options]
+
+  Skill-store hygiene: report junk domains, beacons, duplicates, stale
+  captures, and invalid skill files. Offline — never makes network calls.
+
+  Options:
+    --fix                  Apply safe fixes (quarantine + edit with .orig snapshot)
+    --restore <domain>     Undo a doctor fix or quarantine
+    --verbose              Full per-finding line output (default is a summary)
+    --stale-days <n>       Stale-capture threshold in days (default 90)
+    --json                 Machine-readable full report
+    --help, -h             Show this help
+`;
+
 const APITAP_DIR = process.env.APITAP_DIR || join(homedir(), '.apitap');
 const SKILLS_DIR = process.env.APITAP_SKILLS_DIR || undefined;
 
@@ -2512,6 +2527,10 @@ async function handleForget(positional: string[]): Promise<void> {
 }
 
 async function handleDoctor(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  if (flags.help === true || typeof flags.help === 'string' || positional.includes('-h')) {
+    console.log(DOCTOR_USAGE);
+    return;
+  }
   const skillsDir = SKILLS_DIR || join(APITAP_DIR, 'skills');
   try {
     if (typeof flags.restore === 'string') {

--- a/src/doctor/format.ts
+++ b/src/doctor/format.ts
@@ -38,3 +38,75 @@ export function formatDoctorReport(report: DoctorReport, fixMode: boolean): stri
   }
   return lines.join('\n');
 }
+
+const SEVERITY_WEIGHT: Record<Severity, number> = { junk: 10, warn: 3, info: 1 };
+const TOP_DOMAINS = 10;
+
+export function formatDoctorSummary(report: DoctorReport, fixMode: boolean): string {
+  const lines: string[] = [`apitap doctor — ${report.scanned} skills scanned`, ''];
+  if (report.findings.length === 0) {
+    lines.push('No findings — skill store is clean.');
+    return lines.join('\n');
+  }
+
+  // Per-check counts grouped by severity
+  for (const sev of ORDER) {
+    const group = report.findings.filter(f => f.severity === sev);
+    if (group.length === 0) continue;
+    const byCheck = new Map<string, number>();
+    for (const f of group) byCheck.set(f.checkId, (byCheck.get(f.checkId) ?? 0) + 1);
+    const checks = [...byCheck.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([id, n]) => `${id}: ${n}`)
+      .join(' · ');
+    lines.push(`${HEADER[sev].padEnd(5)} ${String(group.length).padEnd(5)} ${checks}`);
+  }
+  lines.push('');
+
+  // Top domains by severity-weighted finding count
+  const weight = new Map<string, number>();
+  const checksByDomain = new Map<string, Finding[]>();
+  for (const f of report.findings) {
+    weight.set(f.domain, (weight.get(f.domain) ?? 0) + SEVERITY_WEIGHT[f.severity]);
+    let list = checksByDomain.get(f.domain);
+    if (!list) {
+      list = [];
+      checksByDomain.set(f.domain, list);
+    }
+    list.push(f);
+  }
+  const quarantined = new Set(report.quarantined);
+  const fixedKey = new Set(report.fixes.map(x => `${x.domain} ${x.checkId}`));
+  const top = [...weight.entries()].sort((a, b) => b[1] - a[1]).slice(0, TOP_DOMAINS);
+  lines.push('Top domains (severity-weighted):');
+  for (const [domain] of top) {
+    const fs = checksByDomain.get(domain)!;
+    const byCheck = new Map<string, number>();
+    let junk = false;
+    for (const f of fs) {
+      byCheck.set(f.checkId, (byCheck.get(f.checkId) ?? 0) + 1);
+      if (f.severity === 'junk') junk = true;
+    }
+    const parts = [...byCheck.entries()].map(([id, n]) => (n > 1 ? `${id} ×${n}` : id)).join(', ');
+    let tag = '';
+    if (fixMode && quarantined.has(domain)) tag = '  [QUARANTINED]';
+    else if (fixMode && fs.some(f => fixedKey.has(`${domain} ${f.checkId}`))) tag = '  [FIXED]';
+    lines.push(`  ${domain.padEnd(34)} ${junk ? '[JUNK] ' : ''}${parts}${tag}`);
+  }
+  lines.push('');
+
+  // Summary + hints (mirrors formatDoctorReport tail)
+  const fixable = report.findings.filter(f => f.fixable).length;
+  lines.push(`Summary: ${report.findings.length} findings (${fixable} fixable), ${report.fixes.length} fixed, ${report.remaining.length} remaining.`);
+  if (fixMode) {
+    if (report.quarantined.length > 0) {
+      lines.push(`Undo: apitap doctor --restore <domain>  (quarantined: ${report.quarantined.join(', ')})`);
+    } else if (report.fixes.length > 0) {
+      lines.push('Undo: apitap doctor --restore <domain>');
+    }
+  } else if (fixable > 0) {
+    lines.push(`Run \`apitap doctor --fix\` to apply the ${fixable} safe fixes.`);
+  }
+  lines.push('Run `apitap doctor --verbose` or `apitap doctor <domain>` for full detail.');
+  return lines.join('\n');
+}

--- a/test/cli/doctor-cli.test.ts
+++ b/test/cli/doctor-cli.test.ts
@@ -1,11 +1,15 @@
 // test/cli/doctor-cli.test.ts
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { deriveSigningKey } from '../../src/auth/crypto.js';
+import { getMachineId } from '../../src/auth/manager.js';
+import { signSkillFileAs } from '../../src/skill/signing.js';
+import { makeEndpoint, makeSkill } from '../doctor/fixtures.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -55,5 +59,80 @@ describe('doctor --help', () => {
     });
     assert.equal(code, 0);
     assert.match(stdout, /Usage: apitap doctor/);
+  });
+});
+
+describe('doctor summary default', () => {
+  let testDir: string;
+  let skillsDir: string;
+  let baseEnv: Record<string, string>;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'apitap-doctor-cli-summary-'));
+    skillsDir = join(testDir, 'skills');
+    await mkdir(skillsDir, { recursive: true });
+
+    // handleDoctor derives its signing key via `deriveSigningKey(machineId)`
+    // with no saltFile override, so it always reads the real per-install
+    // salt at ~/.apitap/install-salt — never APITAP_DIR. To sign fixtures
+    // the CLI subprocess will accept, mirror that exactly: real machine id
+    // (no APITAP_MACHINE_ID override) + default salt file.
+    const machineId = await getMachineId();
+    const signingKey = deriveSigningKey(machineId);
+
+    // junk domain (capture blocklist) → quarantine-fixable finding
+    await writeFile(join(skillsDir, 'cdn.segment.com.json'), JSON.stringify(
+      signSkillFileAs(makeSkill({ domain: 'cdn.segment.com', baseUrl: 'https://cdn.segment.com' }), signingKey, 'self'),
+    ));
+    // beacon endpoint → warn/fixable finding on a second domain
+    const beaconEp = makeEndpoint({
+      id: 'post-capi', method: 'POST', path: '/capi/meta',
+      responseShape: { type: 'object' }, responseBytes: 0,
+      examples: { request: { url: 'https://mixed-fixture.com/capi/meta', headers: {} }, responsePreview: null },
+    } as any);
+    await writeFile(join(skillsDir, 'mixed-fixture.com.json'), JSON.stringify(
+      signSkillFileAs(makeSkill({
+        domain: 'mixed-fixture.com', baseUrl: 'https://mixed-fixture.com',
+        endpoints: [makeEndpoint(), beaconEp],
+      }), signingKey, 'self'),
+    ));
+    // tampered signature → invalid-signature finding on a third domain
+    const tampered = signSkillFileAs(makeSkill({
+      domain: 'tampered-fixture.com', baseUrl: 'https://tampered-fixture.com',
+    }), signingKey, 'self') as any;
+    tampered.capturedAt = '2026-07-02T00:00:00.000Z'; // breaks the HMAC
+    await writeFile(join(skillsDir, 'tampered-fixture.com.json'), JSON.stringify(tampered));
+
+    baseEnv = { APITAP_DIR: testDir, APITAP_SKILLS_DIR: skillsDir };
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('whole-store run prints summary, not per-finding lines', async () => {
+    const { stdout } = await runCli(['doctor'], baseEnv);
+    assert.match(stdout, /Top domains/);
+    assert.match(stdout, /--verbose/);
+    // per-finding dump line shape "  <domain padded> <check>: <message>" absent
+    assert.doesNotMatch(stdout, /^\s{2}\S+\s{2,}[a-z-]+: /m);
+  });
+
+  it('--verbose restores the full dump', async () => {
+    const { stdout } = await runCli(['doctor', '--verbose'], baseEnv);
+    assert.doesNotMatch(stdout, /Top domains/);
+    assert.match(stdout, /^\s{2}\S+\s{2,}[a-z-]+: /m);
+  });
+
+  it('domain-scoped run keeps full detail without --verbose', async () => {
+    const { stdout } = await runCli(['doctor', 'mixed-fixture.com'], baseEnv);
+    assert.doesNotMatch(stdout, /Top domains/);
+  });
+
+  it('--json output is unchanged (full DoctorReport)', async () => {
+    const { stdout } = await runCli(['doctor', '--json'], baseEnv);
+    const parsed = JSON.parse(stdout);
+    assert.ok(Array.isArray(parsed.findings));
+    assert.equal(typeof parsed.scanned, 'number');
   });
 });

--- a/test/cli/doctor-cli.test.ts
+++ b/test/cli/doctor-cli.test.ts
@@ -1,0 +1,59 @@
+// test/cli/doctor-cli.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+async function runCli(args: string[], env?: Record<string, string>): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      'node',
+      ['--import', 'tsx', 'src/cli.ts', ...args],
+      { env: { ...process.env, ...env }, timeout: 10000 },
+    );
+    return { stdout, stderr, code: 0 };
+  } catch (err: any) {
+    return { stdout: err.stdout ?? '', stderr: err.stderr ?? '', code: typeof err.code === 'number' ? err.code : 1 };
+  }
+}
+
+describe('doctor --help', () => {
+  let testDir: string;
+  let skillsDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'apitap-doctor-cli-'));
+    skillsDir = join(testDir, 'skills');
+    await mkdir(skillsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('prints usage and exits 0 without scanning', async () => {
+    const { stdout, code } = await runCli(['doctor', '--help'], {
+      APITAP_DIR: testDir,
+      APITAP_SKILLS_DIR: skillsDir,
+      APITAP_MACHINE_ID: 'test-machine-id',
+    });
+    assert.equal(code, 0);
+    assert.match(stdout, /Usage: apitap doctor/);
+    assert.doesNotMatch(stdout, /skills scanned/);
+  });
+
+  it('treats -h positional as help', async () => {
+    const { stdout, code } = await runCli(['doctor', '-h'], {
+      APITAP_DIR: testDir,
+      APITAP_SKILLS_DIR: skillsDir,
+      APITAP_MACHINE_ID: 'test-machine-id',
+    });
+    assert.equal(code, 0);
+    assert.match(stdout, /Usage: apitap doctor/);
+  });
+});

--- a/test/doctor/format.test.ts
+++ b/test/doctor/format.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { formatDoctorSummary, formatDoctorReport } from '../../src/doctor/format.js';
+import type { DoctorReport, Finding } from '../../src/doctor/types.js';
+
+function finding(over: Partial<Finding>): Finding {
+  return { checkId: 'stale-capture', domain: 'a.com', severity: 'warn', message: 'stale', fixable: false, ...over };
+}
+
+function report(findings: Finding[], over: Partial<DoctorReport> = {}): DoctorReport {
+  return { scanned: 10, findings, fixes: [], remaining: findings, quarantined: [], ...over };
+}
+
+describe('formatDoctorSummary', () => {
+  it('prints per-check counts grouped by severity, not per-finding lines', () => {
+    const findings = [
+      finding({ domain: 'junky.com', checkId: 'junk-domain', severity: 'junk' }),
+      ...Array.from({ length: 5 }, (_, i) => finding({ domain: `w${i}.com` })),
+      finding({ domain: 'w0.com', checkId: 'unverified-tier', severity: 'info' }),
+    ];
+    const out = formatDoctorSummary(report(findings), false);
+    assert.match(out, /10 skills scanned/);
+    assert.match(out, /JUNK\s+1/);
+    assert.match(out, /junk-domain: 1/);
+    assert.match(out, /WARN\s+5/);
+    assert.match(out, /stale-capture: 5/);
+    // No per-finding dump: each warn domain appears at most in the top-domains block, not one line per finding
+    assert.doesNotMatch(out, /w3\.com\s+stale-capture: stale/);
+  });
+
+  it('ranks top domains by severity weight (junk=10, warn=3, info=1) and caps at 10', () => {
+    const findings = [
+      finding({ domain: 'junky.com', checkId: 'junk-domain', severity: 'junk' }),
+      ...Array.from({ length: 4 }, () => finding({ domain: 'warny.com' })), // weight 12
+      ...Array.from({ length: 12 }, (_, i) => finding({ domain: `d${i}.com` })), // weight 3 each
+    ];
+    const out = formatDoctorSummary(report(findings), false);
+    const topBlock = out.slice(out.indexOf('Top domains'));
+    const warnyPos = topBlock.indexOf('warny.com');
+    const junkyPos = topBlock.indexOf('junky.com');
+    assert.ok(warnyPos !== -1 && junkyPos !== -1);
+    assert.ok(warnyPos < junkyPos, 'warny (12) ranks above junky (10)');
+    const listed = topBlock.match(/d\d+\.com/g) ?? [];
+    assert.ok(listed.length <= 8, 'top-domains block capped at 10 total domains');
+  });
+
+  it('keeps the fix hint and adds verbose hint', () => {
+    const findings = [finding({ fixable: true })];
+    const out = formatDoctorSummary(report(findings), false);
+    assert.match(out, /apitap doctor --fix/);
+    assert.match(out, /--verbose/);
+  });
+
+  it('annotates quarantined domains in fix mode', () => {
+    const f = finding({ domain: 'bad.com', checkId: 'empty-skill', fixable: true });
+    const r = report([f], {
+      fixes: [{ domain: 'bad.com', checkId: 'empty-skill', action: 'quarantine' }],
+      quarantined: ['bad.com'],
+      remaining: [],
+    });
+    const out = formatDoctorSummary(r, true);
+    assert.match(out, /bad\.com.*\[QUARANTINED\]/);
+    assert.match(out, /--restore/);
+  });
+
+  it('clean store prints the clean message', () => {
+    const out = formatDoctorSummary(report([]), false);
+    assert.match(out, /clean/);
+  });
+});


### PR DESCRIPTION
Closes out two items from the 2026-07-19 dogfood gauntlet.

## What

- **\`apitap doctor --help\` / \`-h\` prints usage** instead of running a full store scan (the house arg parser treated \`-h\` as a domain).
- **Whole-store \`apitap doctor\` now defaults to a summary**: per-check counts grouped by severity, top-10 domains ranked by severity-weighted finding count (junk=10, warn=3, info=1), and the fix/verbose hints. The previous full per-finding dump (376 WARN lines on a real store) moves behind \`--verbose\`. Domain-scoped runs (\`apitap doctor <domain>\`) keep full detail — they're already small.
- \`--json\` output and exit codes are unchanged.

## Real-store before/after

Before: 376 WARN lines drowning one JUNK finding. After (real 324-skill store):

\`\`\`
apitap doctor — 324 skills scanned

JUNK  1     beacon-endpoints: 1
WARN  376   stale-capture: 315 · duplicate-endpoints: 45 · invalid-signature: 9 · junk-domain: 5 · beacon-endpoints: 2
INFO  275   unverified-tier: 262 · unparameterized-paths: 13

Top domains (severity-weighted):
  tripletex.no                       duplicate-endpoints ×5, stale-capture, unverified-tier
  mon16-normal-useast5.tiktokv.us    [JUNK] invalid-signature, beacon-endpoints, stale-capture
  ...

Summary: 652 findings (1 fixable), 0 fixed, 652 remaining.
Run \`apitap doctor --fix\` to apply the 1 safe fixes.
Run \`apitap doctor --verbose\` or \`apitap doctor <domain>\` for full detail.
\`\`\`

## Tests

1697 passing (+9: help guard, summary formatter unit tests, CLI wiring with real fixture stores), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQaJk5nQXmddqC2P4ZQrVz