### PR TITLE
search: locality+tier+provenance ranking demotes apis.guru import noise

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -99,7 +99,7 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
         'Returns endpoints with replayability tier (green/yellow/orange/red) and endpoint IDs for replay.',
       inputSchema: z.object({
         query: z.string().describe('Search query — domain name, endpoint path, or keyword (e.g. "polymarket", "events", "get-markets")'),
-        limit: z.number().optional().describe('Maximum results to return (default: 50). Results are ranked by replayability tier when truncated.'),
+        limit: z.number().optional().describe('Maximum results to return (default: 50). Results are ranked by match locality (domain > endpoint > path), replayability tier, then provenance (own captures above imports).'),
       }),
       annotations: {
         readOnlyHint: true,

--- a/src/skill/search.ts
+++ b/src/skill/search.ts
@@ -8,6 +8,7 @@ export interface SearchResult {
   path: string;
   tier: string;
   verified: boolean;
+  provenance: string;
 }
 
 export interface SearchResponse {
@@ -30,6 +31,11 @@ const SUGGESTION_DOMAIN_CAP = 20;
 /** Lower rank = kept first when truncating */
 export const TIER_RANK: Record<string, number> = { green: 0, yellow: 1, unknown: 2, orange: 3, red: 4 };
 
+/** Lower rank = kept first when tier and locality tie */
+export const PROVENANCE_RANK: Record<string, number> = {
+  self: 0, 'imported-signed': 1, imported: 2, unsigned: 3,
+};
+
 /**
  * Check if a search term matches a target string.
  * Supports prefix matching: "payment" matches "payments", "pay" matches "payouts".
@@ -43,6 +49,13 @@ function termMatches(term: string, text: string): boolean {
   }
   // Also check plain substring for multi-word or partial path matches
   return text.includes(term);
+}
+
+/** 0 = every term matches the domain, 1 = every term matches domain or endpoint id, 2 = path/method only */
+function matchLocality(terms: string[], domain: string, endpointId: string): number {
+  if (terms.every(t => termMatches(t, domain))) return 0;
+  if (terms.every(t => termMatches(t, domain) || termMatches(t, endpointId))) return 1;
+  return 2;
 }
 
 /**
@@ -69,6 +82,7 @@ export async function searchSkills(
 
   const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
   const results: SearchResult[] = [];
+  const localities: number[] = [];
   const matchedDomains = new Set<string>();
 
   for (const [domain, entry] of Object.entries(index.domains)) {
@@ -91,7 +105,9 @@ export async function searchSkills(
           path: ep.path,
           tier: ep.tier ?? 'unknown',
           verified: ep.verified ?? false,
+          provenance: entry.provenance ?? 'unsigned',
         });
+        localities.push(matchLocality(terms, domainLower, endpointIdLower));
       }
     }
   }
@@ -109,21 +125,28 @@ export async function searchSkills(
   }
 
   const domainPlural = `domain${matchedDomains.size === 1 ? '' : 's'}`;
+
+  // Rank by match locality (domain > endpoint > path), then replayability tier,
+  // then provenance (own captures above imports), stable within ties.
+  const ranked = results
+    .map((r, i) => ({ r, i, loc: localities[i] }))
+    .sort((a, b) =>
+      a.loc - b.loc ||
+      (TIER_RANK[a.r.tier] ?? 2) - (TIER_RANK[b.r.tier] ?? 2) ||
+      (PROVENANCE_RANK[a.r.provenance] ?? 3) - (PROVENANCE_RANK[b.r.provenance] ?? 3) ||
+      a.i - b.i,
+    )
+    .map(({ r }) => r);
+
   if (results.length > limit) {
-    // Keep the most replayable results; stable within tier
-    const kept = results
-      .map((r, i) => ({ r, i }))
-      .sort((a, b) => (TIER_RANK[a.r.tier] ?? 2) - (TIER_RANK[b.r.tier] ?? 2) || a.i - b.i)
-      .slice(0, limit)
-      .map(({ r }) => r);
     return {
       found: true,
-      results: kept,
+      results: ranked.slice(0, limit),
       truncated: true,
       summary: `showing ${limit} of ${results.length} endpoints across ${matchedDomains.size} ${domainPlural} — narrow the query or raise limit`,
     };
   }
 
   const summary = `${results.length} endpoints across ${matchedDomains.size} ${domainPlural}`;
-  return { found: true, results, summary };
+  return { found: true, results: ranked.slice(0, limit), summary };
 }

--- a/test/skill/search.test.ts
+++ b/test/skill/search.test.ts
@@ -8,7 +8,11 @@ import { writeSkillFile } from '../../src/skill/store.js';
 import { searchSkills } from '../../src/skill/search.js';
 import type { SkillFile } from '../../src/types.js';
 
-function makeSkill(domain: string, endpoints: Array<{ id: string; method: string; path: string; tier?: string }>): SkillFile {
+function makeSkill(
+  domain: string,
+  endpoints: Array<{ id: string; method: string; path: string; tier?: string }>,
+  provenance: string = 'self',
+): SkillFile {
   return {
     version: '1.2',
     domain,
@@ -32,7 +36,7 @@ function makeSkill(domain: string, endpoints: Array<{ id: string; method: string
       },
     })),
     metadata: { captureCount: 1, filteredCount: 0, toolVersion: '0.4.0' },
-    provenance: 'self',
+    provenance: provenance as SkillFile['provenance'],
   };
 }
 
@@ -173,6 +177,74 @@ describe('searchSkills', () => {
       assert.equal(results.found, false);
       assert.ok(results.suggestion!.length < 1500, `suggestion too long: ${results.suggestion!.length}`);
       assert.match(results.suggestion!, /and \d+ more/);
+    });
+  });
+
+  describe('search ranking', () => {
+    beforeEach(async () => {
+      // api.github.com already exists from the outer beforeEach:
+      // provenance 'self', tier green/yellow, path /repos and /issues (domain match on 'github').
+      // apis.guru: provenance 'imported', tier unknown, 3 endpoints with 'github' in the path only.
+      await writeSkillFile(makeSkill('apis.guru', [
+        { id: 'get-repos-github', method: 'GET', path: '/repos/github', tier: 'unknown' },
+        { id: 'get-orgs-github', method: 'GET', path: '/orgs/github', tier: 'unknown' },
+        { id: 'get-users-github', method: 'GET', path: '/users/github', tier: 'unknown' },
+      ], 'imported'), testDir);
+
+      // 'widget' path match, equal tier (unknown), differing provenance.
+      await writeSkillFile(makeSkill('store-imported.example.com', [
+        { id: 'get-item', method: 'GET', path: '/widget/1', tier: 'unknown' },
+      ], 'imported'), testDir);
+      await writeSkillFile(makeSkill('store-self.example.com', [
+        { id: 'get-item', method: 'GET', path: '/widget/2', tier: 'unknown' },
+      ], 'self'), testDir);
+
+      // 'gadget' path match, equal locality, differing tier — tier should decide over provenance.
+      await writeSkillFile(makeSkill('shopa.example.com', [
+        { id: 'get-item', method: 'GET', path: '/gadget/a', tier: 'green' },
+      ], 'imported'), testDir);
+      await writeSkillFile(makeSkill('shopb.example.com', [
+        { id: 'get-item', method: 'GET', path: '/gadget/b', tier: 'unknown' },
+      ], 'self'), testDir);
+
+      // 'thing' — domain match (red tier) must outrank path-substring match (green tier).
+      await writeSkillFile(makeSkill('api.thing.com', [
+        { id: 'get-root', method: 'GET', path: '/root', tier: 'red' },
+      ], 'self'), testDir);
+      await writeSkillFile(makeSkill('other.example.com', [
+        { id: 'get-item', method: 'GET', path: '/thing/1', tier: 'green' },
+      ], 'self'), testDir);
+    });
+
+    it('domain match outranks path-substring match regardless of count', async () => {
+      const res = await searchSkills('github', testDir);
+      assert.equal(res.results![0].domain, 'api.github.com');
+    });
+
+    it('self provenance outranks imported at equal tier and locality', async () => {
+      const res = await searchSkills('widget', testDir);
+      assert.equal(res.results![0].provenance, 'self');
+    });
+
+    it('tier beats provenance after locality: green-imported above unknown-self', async () => {
+      const res = await searchSkills('gadget', testDir);
+      assert.equal(res.results![0].tier, 'green');
+    });
+
+    it('locality beats tier: red-tier domain match outranks green-tier path-substring match (deliberate)', async () => {
+      const res = await searchSkills('thing', testDir);
+      assert.equal(res.results![0].domain, 'api.thing.com');
+    });
+
+    it('results carry provenance', async () => {
+      const res = await searchSkills('github', testDir);
+      assert.ok(res.results!.every(r => typeof r.provenance === 'string'));
+    });
+
+    it('sorts even when under the limit', async () => {
+      const res = await searchSkills('github', testDir, { limit: 50 });
+      // domain-match block first, then ordered by tier within same locality — no unknown before green at same locality
+      assert.equal(res.results![0].domain, 'api.github.com');
     });
   });
 });


### PR DESCRIPTION
Gauntlet finding: `apitap search github` surfaced 50 apis.guru path-substring hits (all tier unknown) above `api.github.com`'s captured endpoints.

## What

`searchSkills` now sorts ALL results (previously only when over the 50-cap) by a composite key:

1. **Match locality** — every term matches the domain (0) > domain-or-endpoint-id (1) > path/method only (2)
2. **Tier** — existing `TIER_RANK` (green → red)
3. **Provenance** — `self` > `imported-signed` > `imported` > `unsigned` (new `PROVENANCE_RANK`)
4. Stable original index

`SearchResult` gains an additive `provenance` field so agents can see why a result ranked. The MCP `apitap_search` description documents the new order.

Deliberate call, pinned by a test: a red-tier domain match outranks a green-tier path-substring match — if you searched for the thing by name, the domain you named wins.

## Real-store eye-check

`search github` now returns `api.github.com` / `github.com` domain matches first; apis.guru path noise falls below the top-50 window.

## Tests

1692 passing (6 new ranking tests incl. the locality-beats-tier pin), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQaJk5nQXmddqC2P4ZQrVz