### PR TITLE
maxBytes is now a hard envelope cap + envelopeBytes everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ monitoring/
 .traction-state
 tasks/
 launch-monitor-baseline.json
+implementation-notes.md

--- a/README.md
+++ b/README.md
@@ -225,6 +225,21 @@ apitap read https://example.com/blog/post
 
 For MCP agents, `apitap_peek` and `apitap_read` are the fastest way to consume web content — use them before reaching for `apitap_browse` or `apitap_capture`.
 
+### Bounding response size with `--max-bytes`
+
+`--max-bytes` (MCP: `maxBytes`) is a **hard cap on the full serialized response envelope**, not just on the data or content field. It applies uniformly across `apitap replay`, `apitap browse`, and `apitap read` (including every built-in decoder — Wikipedia, Hacker News, Reddit, etc.), so a bounded call returns a bounded envelope no matter which path served it.
+
+```bash
+apitap replay gamma-api.polymarket.com get-events --json --max-bytes 4000
+apitap read https://en.wikipedia.org/wiki/Node.js --max-bytes 4000
+```
+
+How the cap is honoured:
+
+- **Read path** — links are shrunk first (deduped, then halved), then content is re-sliced byte-accurately. When content is cut, the envelope carries `contentTruncated: true` so the truncation is never silent.
+- **Replay path** — the data payload is trimmed to fit under the same budget, flooring at a **512-byte data minimum** so a pathologically small `--max-bytes` still returns usable data (the only documented case where the envelope may exceed the cap).
+- **`envelopeBytes`** — every capped response reports its own actual serialized size in bytes. It is recorded after the diet runs, so `envelopeBytes ≤ maxBytes` (within a few bytes of fixed-width measurement slack), except in the floor case above where irreducible data plus never-dropped metadata can honestly exceed the budget. Use it to see how much of the budget a response actually consumed.
+
 ## Pre-Loaded APIs
 
 ApiTap can instantly import from the [APIs.guru](https://apis.guru) directory of 2,500+ public API specs. A single command populates your local pattern database:

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -1,8 +1,0 @@
-# Implementation notes — workstream D
-
-## Deviations
-
-- (spec) read keeps #62 loop as fitReadEnvelope instead of capEnvelope — link-shrink semantics; applied to decoder path too (grok P0-1).
-- (plan Task 5) removed eager no-progress break in capEnvelope loop — escalating budget shave is the progress mechanism; plateau cases previously overshot ~6% under indented serializer, violating spec hard-cap intent. Also deduped mergeInfo note. Implementer-flagged, controller-approved.
-- (plan Task 5, round 2) fixed-shave loop → bisection on measured serialized bytes; reviewer C1 proved plan algorithm porous under indent (+42% flat array). Floor-first fallback, best-fit ≤8 rounds.
-- (Task 6) handleBrowse's `--json` guidance branch (BrowseGuidance, `success: false`) has no bulk `data` field, so full `capEnvelope` bisection is unnecessary there — used the same placeholder-then-patch trick directly (measure `{...result, envelopeBytes: 999_999_999}`, patch real value in) without invoking `capEnvelope`. `envelopeBytes` is still always present on browse `--json` output, per brief interface note, for both success and guidance shapes. No plan deviation from Task 6 brief itself — brief only showed the replay wiring in detail and left browse as "same pattern"; this is the natural adaptation for its two-variant result type.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -1,0 +1,8 @@
+# Implementation notes — workstream D
+
+## Deviations
+
+- (spec) read keeps #62 loop as fitReadEnvelope instead of capEnvelope — link-shrink semantics; applied to decoder path too (grok P0-1).
+- (plan Task 5) removed eager no-progress break in capEnvelope loop — escalating budget shave is the progress mechanism; plateau cases previously overshot ~6% under indented serializer, violating spec hard-cap intent. Also deduped mergeInfo note. Implementer-flagged, controller-approved.
+- (plan Task 5, round 2) fixed-shave loop → bisection on measured serialized bytes; reviewer C1 proved plan algorithm porous under indent (+42% flat array). Floor-first fallback, best-fit ≤8 rounds.
+- (Task 6) handleBrowse's `--json` guidance branch (BrowseGuidance, `success: false`) has no bulk `data` field, so full `capEnvelope` bisection is unnecessary there — used the same placeholder-then-patch trick directly (measure `{...result, envelopeBytes: 999_999_999}`, patch real value in) without invoking `capEnvelope`. `envelopeBytes` is still always present on browse `--json` output, per brief interface note, for both success and guidance shapes. No plan deviation from Task 6 brief itself — brief only showed the replay wiring in detail and left browse as "same pattern"; this is the natural adaptation for its two-variant result type.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,7 +145,7 @@ function printUsage(): void {
   Replay options:
     --json                     Output machine-readable JSON
     --fresh                    Force token refresh before replay
-    --max-bytes <bytes>        Truncate response to fit within byte limit
+    --max-bytes <bytes>        Cap the full serialized response at this many bytes
     --egress-check             Enable egress scanning for this call (annotate mode)
     --egress-check=annotate    Explicit annotate mode
     --egress-check=block       Explicit block mode (refuses on high-severity)
@@ -158,14 +158,14 @@ function printUsage(): void {
 
   Browse options:
     --json                     Output machine-readable JSON
-    --max-bytes <bytes>        Truncate response to fit within byte limit (default: 50000)
+    --max-bytes <bytes>        Cap the full serialized response at this many bytes (default: 50000)
 
   Peek options:
     --json                     Output machine-readable JSON
 
   Read options:
     --json                     Output machine-readable JSON
-    --max-bytes <bytes>        Truncate content to fit within byte limit
+    --max-bytes <bytes>        Cap the full serialized response at this many bytes
     --scan                     Enable trap-aware content scanning (default)
     --no-scan                  Disable trap-aware content scanning
     --images                   Include the images array (deduped, capped at 50)
@@ -2359,7 +2359,7 @@ async function handleRead(positional: string[], flags: Record<string, string | b
   }
 
   if (json) {
-    console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify(result));
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import { capture } from './capture/monitor.js';
 import { writeSkillFile, readSkillFile, listSkillFiles } from './skill/store.js';
 import { replayEndpoint, getConfidenceHint } from './replay/engine.js';
+import { capEnvelope } from './replay/envelope.js';
 import { AuthManager, getMachineId } from './auth/manager.js';
 import { deriveSigningKey } from './auth/crypto.js';
 import { signSkillFile, signSkillFileAs, provenanceForSigning } from './skill/signing.js';
@@ -538,13 +539,21 @@ async function handleReplay(positional: string[], flags: Record<string, string |
   }
 
   if (json) {
-    console.log(JSON.stringify({
-      status: result.status,
-      data: result.data,
-      ...(result.truncated ? { truncated: result.truncated } : {}),
-      ...(result.contractWarnings?.length ? { contractWarnings: result.contractWarnings } : {}),
-      ...(result.warnings?.length ? { warnings: result.warnings } : {}),
-    }, null, 2));
+    const { envelope, envelopeBytes } = capEnvelope(
+      (data, truncated) => ({
+        status: result.status,
+        data,
+        ...(truncated ? { truncated } : {}),
+        ...(result.contractWarnings?.length ? { contractWarnings: result.contractWarnings } : {}),
+        ...(result.warnings?.length ? { warnings: result.warnings } : {}),
+        envelopeBytes: 999_999_999, // placeholder, same order of magnitude → stable width
+      }),
+      result.data,
+      result.truncated ?? false,
+      maxBytes,
+      env => JSON.stringify(env, null, 2),
+    );
+    console.log(JSON.stringify({ ...envelope, envelopeBytes }, null, 2));
   } else {
     const hint = endpoint ? getConfidenceHint(endpoint.confidence, endpoint.endpointProvenance) : null;
     if (hint) {
@@ -2235,7 +2244,27 @@ async function handleBrowse(positional: string[], flags: Record<string, string |
   });
 
   if (json) {
-    console.log(JSON.stringify(result, null, 2));
+    if (result.success) {
+      const { envelope, envelopeBytes } = capEnvelope(
+        (data, truncated) => ({
+          ...result,
+          data,
+          ...(truncated ? { truncated } : {}),
+          envelopeBytes: 999_999_999, // placeholder, same order of magnitude → stable width
+        }),
+        result.data,
+        result.truncated ?? false,
+        maxBytes,
+        env => JSON.stringify(env, null, 2),
+      );
+      console.log(JSON.stringify({ ...envelope, envelopeBytes }, null, 2));
+    } else {
+      // Guidance responses carry no bulk `data` field — no bisection needed,
+      // just measure with the same placeholder-then-patch trick for stable width.
+      const withPlaceholder = { ...result, envelopeBytes: 999_999_999 };
+      const envelopeBytes = Buffer.byteLength(JSON.stringify(withPlaceholder, null, 2), 'utf-8');
+      console.log(JSON.stringify({ ...result, envelopeBytes }, null, 2));
+    }
     return;
   }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -352,7 +352,11 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
       });
       // Always mark as untrusted — failed results may contain attacker-controlled strings (H7 fix)
       if (!result.success) {
-        return wrapExternalContent(result, 'apitap_browse');
+        // Guidance responses carry no bulk `data` field — no bisection needed,
+        // just measure with the same placeholder-then-patch trick for stable width.
+        const withPlaceholder = { ...result, envelopeBytes: 999_999_999 };
+        const envelopeBytes = Buffer.byteLength(JSON.stringify(withPlaceholder), 'utf-8');
+        return wrapExternalContent({ ...result, envelopeBytes }, 'apitap_browse');
       }
       const { envelope, envelopeBytes } = capEnvelope(
         (data, truncated) => ({

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { searchSkills } from './skill/search.js';
 import { readSkillFile } from './skill/store.js';
 import { replayEndpoint } from './replay/engine.js';
+import { capEnvelope } from './replay/envelope.js';
 import { AuthManager, getMachineId } from './auth/manager.js';
 import { deriveSigningKey } from './auth/crypto.js';
 import { requestAuth } from './auth/handoff.js';
@@ -180,7 +181,7 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
         endpointId: z.string().describe('Endpoint ID from search results (e.g. "get-events", "post-graphql-GetPosts")'),
         params: z.object({}).passthrough().optional().describe('Optional key-value parameters: path params (id), query params, or body variables (variables.limit for GraphQL)'),
         fresh: z.boolean().optional().describe('Force token refresh before replay (opens browser to capture fresh CSRF/session tokens)'),
-        maxBytes: z.number().optional().describe('Maximum response size in bytes. Large responses are truncated to fit. Omit for unlimited.'),
+        maxBytes: z.number().optional().describe('Maximum size in bytes of the full serialized response. Large responses are truncated to fit.'),
         egress_check: z.union([z.literal(false), z.enum(['annotate', 'block'])]).optional().describe('Per-call egress check override. false forces off; "annotate" or "block" force on with that action. Unset falls through to skill file and global config.'),
       }),
       annotations: {
@@ -226,18 +227,24 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
         const cached = sessionCache.get(domain);
         const skillSource = cached?.source ?? 'disk';
 
-        return wrapExternalContent({
+        const { envelope, envelopeBytes } = capEnvelope(
+          (data, truncated) => ({
             status: result.status,
-            data: result.data,
+            data,
             domain,
             endpointId,
             tier: endpoint.replayability?.tier ?? 'unknown',
             skillSource,
             capturedAt: skill.capturedAt,
             ...(result.refreshed ? { refreshed: result.refreshed } : {}),
-            ...(result.truncated ? { truncated: result.truncated } : {}),
+            ...(truncated ? { truncated } : {}),
             ...(result.contractWarnings?.length ? { contractWarnings: result.contractWarnings } : {}),
-          }, 'apitap_replay');
+            envelopeBytes: 999_999_999,
+          }),
+          result.data, result.truncated ?? false, maxBytes,
+          env => JSON.stringify(env),
+        );
+        return wrapExternalContent({ ...envelope, envelopeBytes }, 'apitap_replay');
       } catch (err: any) {
         return {
           content: [{ type: 'text' as const, text: `Replay failed: ${err.message}` }],
@@ -260,7 +267,7 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
           endpointId: z.string().describe('Endpoint ID from search results'),
           params: z.object({}).passthrough().optional().describe('Optional key-value parameters'),
         })).describe('Array of replay requests to execute in parallel'),
-        maxBytes: z.number().optional().describe('Maximum response size in bytes per result. Large responses are truncated to fit.'),
+        maxBytes: z.number().optional().describe('Maximum size in bytes of the full serialized response. Large responses are truncated to fit.'),
       }),
       annotations: {
         readOnlyHint: true,
@@ -281,7 +288,27 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
         params: r.params as Record<string, string> | undefined,
       }));
       const results = await replayMultiple(typed, { skillsDir, maxBytes, _skipSsrfCheck: options._skipSsrfCheck });
-      return wrapExternalContent(results, 'apitap_replay_batch');
+      const capped = results.map(r => {
+        const { envelope, envelopeBytes } = capEnvelope(
+          (data, truncated) => ({
+            domain: r.domain,
+            endpointId: r.endpointId,
+            status: r.status,
+            data,
+            ...(r.error !== undefined ? { error: r.error } : {}),
+            ...(r.tier !== undefined ? { tier: r.tier } : {}),
+            ...(r.capturedAt !== undefined ? { capturedAt: r.capturedAt } : {}),
+            ...(truncated ? { truncated } : {}),
+            ...(r.contractWarnings?.length ? { contractWarnings: r.contractWarnings } : {}),
+            ...(r.skillSource !== undefined ? { skillSource: r.skillSource } : {}),
+            envelopeBytes: 999_999_999,
+          }),
+          r.data, r.truncated ?? false, maxBytes,
+          env => JSON.stringify(env),
+        );
+        return { ...envelope, envelopeBytes };
+      });
+      return wrapExternalContent(capped, 'apitap_replay_batch');
     },
   );
 
@@ -295,7 +322,7 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
       inputSchema: z.object({
         url: z.string().describe('URL to browse (e.g. "https://zillow.com/rentals/portland")'),
         task: z.string().optional().describe('Optional task description (e.g. "find apartments under $1500") — passed through in response for correlation'),
-        maxBytes: z.number().optional().describe('Maximum response size in bytes (default: 50000). Large responses are truncated to fit.'),
+        maxBytes: z.number().optional().describe('Maximum size in bytes of the full serialized response. Large responses are truncated to fit.'),
       }),
       annotations: {
         readOnlyHint: true,
@@ -313,17 +340,38 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
         }
       }
       const { browse: doBrowse } = await import('./orchestration/browse.js');
+      const effectiveMaxBytes = maxBytes ?? 50_000;
       const result = await doBrowse(url, {
         skillsDir,
         cache: sessionCache,
         task,
-        maxBytes: maxBytes ?? 50_000,
+        maxBytes: effectiveMaxBytes,
         _skipSsrfCheck: options._skipSsrfCheck,
         // In test mode, disable bridge to avoid connecting to real socket
         ...(options._skipSsrfCheck ? { _bridgeSocketPath: '/nonexistent' } : {}),
       });
       // Always mark as untrusted — failed results may contain attacker-controlled strings (H7 fix)
-      return wrapExternalContent(result, 'apitap_browse');
+      if (!result.success) {
+        return wrapExternalContent(result, 'apitap_browse');
+      }
+      const { envelope, envelopeBytes } = capEnvelope(
+        (data, truncated) => ({
+          success: true as const,
+          data,
+          status: result.status,
+          domain: result.domain,
+          endpointId: result.endpointId,
+          tier: result.tier,
+          skillSource: result.skillSource,
+          capturedAt: result.capturedAt,
+          ...(result.task !== undefined ? { task: result.task } : {}),
+          ...(truncated ? { truncated } : {}),
+          envelopeBytes: 999_999_999,
+        }),
+        result.data, result.truncated ?? false, effectiveMaxBytes,
+        env => JSON.stringify(env),
+      );
+      return wrapExternalContent({ ...envelope, envelopeBytes }, 'apitap_browse');
     },
   );
 
@@ -374,7 +422,7 @@ export function createMcpServer(options: McpServerOptions = {}): McpServer {
         'HTML extraction elsewhere. Returns clean markdown. ~10K tokens vs 200K for browser.',
       inputSchema: z.object({
         url: z.string().describe('URL to read (e.g. "https://en.wikipedia.org/wiki/TypeScript")'),
-        maxBytes: z.number().optional().describe('Maximum content size in bytes. Content is truncated to fit.'),
+        maxBytes: z.number().optional().describe('Maximum size in bytes of the full serialized response. Large responses are truncated to fit.'),
         scan: z.boolean().optional().describe('Enable trap-aware content scanning (default: true). Set to false to skip scanning and preserve the legacy response envelope shape.'),
         includeImages: z.boolean().optional().describe('Include the images array (deduped, capped at 50). Default: false.'),
       }),

--- a/src/read/index.ts
+++ b/src/read/index.ts
@@ -25,10 +25,79 @@ export interface ReadOptions {
   scan?: boolean;
   /** Include the images array in the envelope (deduped, capped). Default: false. */
   includeImages?: boolean;
+  /** Testing-only override for a decoder's API base URL. Forwarded to the
+   *  matched decoder so tests can point it at a local fixture server. */
+  _apiBaseUrl?: string;
 }
 
 const LINKS_CAP = 100;
 const IMAGES_CAP = 50;
+
+/**
+ * Fit a ReadResult envelope inside maxBytes (issue #62 semantics): shrink the
+ * links array by halving first, then binary-search the largest content prefix
+ * whose fully serialized envelope fits. Byte-accurate — measured against
+ * JSON.stringify(envelope), so any field already on the object (findings,
+ * envelopeBytes placeholder, cost) is counted. Sets contentTruncated when the
+ * content had to be cut. Applied to BOTH the generic and decoder return paths
+ * so maxBytes is one hard cap everywhere. No-op when maxBytes is undefined.
+ * Callers record envelopeBytes and recompute cost.tokens after this returns.
+ */
+function fitReadEnvelope(envelope: ReadResult, maxBytes: number | undefined): void {
+  if (maxBytes) {
+    // cost.tokens is recomputed by the caller after this returns; measure with
+    // its widest possible value here so the final (smaller) number never grows
+    // the envelope past the budget we just enforced.
+    envelope.cost.tokens = Math.ceil(maxBytes / 4);
+
+    // Shrink links (halving) before touching content.
+    while (
+      Buffer.byteLength(JSON.stringify(envelope), 'utf-8') > maxBytes &&
+      envelope.links.length > 0
+    ) {
+      const keep = Math.floor(envelope.links.length / 2);
+      envelope.linksOmitted = (envelope.linksOmitted ?? 0) + (envelope.links.length - keep);
+      envelope.links = envelope.links.slice(0, keep);
+    }
+
+    // Links exhausted but still over budget: binary-search the largest content
+    // prefix whose full envelope fits (issue #62). Byte-accurate. Only fixed
+    // metadata larger than maxBytes itself can still overshoot.
+    if (
+      Buffer.byteLength(JSON.stringify(envelope), 'utf-8') > maxBytes &&
+      envelope.content.length > 0
+    ) {
+      const full = envelope.content;
+      const suffix = '... [truncated]';
+      // Set the signal BEFORE measuring so its own bytes are budgeted.
+      envelope.contentTruncated = true;
+      let lo = 0;
+      let hi = full.length;
+      while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        envelope.content = full.slice(0, mid) + suffix;
+        if (Buffer.byteLength(JSON.stringify(envelope), 'utf-8') <= maxBytes) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      envelope.content = full.slice(0, lo) + suffix;
+    }
+  }
+}
+
+/**
+ * Record envelopeBytes (fixed-width placeholder trick) and recompute cost.tokens
+ * as the final mutations, in that order — cost.tokens is last so it stays an
+ * exact measure of the settled envelope. Shared by both read return paths.
+ */
+function fitAndFinalize(envelope: ReadResult, maxBytes: number | undefined): void {
+  envelope.envelopeBytes = 999_999_999; // placeholder counted by the re-slice budget
+  fitReadEnvelope(envelope, maxBytes);
+  envelope.envelopeBytes = Buffer.byteLength(JSON.stringify(envelope), 'utf-8');
+  envelope.cost = { tokens: Math.ceil(JSON.stringify(envelope).length / 4) };
+}
 
 function dietLinks(links: Array<{ text: string; href: string }>): Array<{ text: string; href: string }> {
   const seen = new Set<string>();
@@ -76,13 +145,20 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
   // Try site-specific decoder first
   const decoder = findDecoder(url);
   if (decoder) {
-    const result = await decoder.decode(url, { skipSsrf: options.skipSsrf });
+    const result = await decoder.decode(url, {
+      skipSsrf: options.skipSsrf,
+      ...(options._apiBaseUrl ? { _apiBaseUrl: options._apiBaseUrl } : {}),
+    });
     if (result) {
+      // Cheap first pass: char-slice to roughly bound content, then run the
+      // same byte-accurate envelope diet the generic path uses (grok P0-1:
+      // decoder results must honour maxBytes as a hard cap, not just a
+      // character slice, and must report envelopeBytes like every other path).
       if (options.maxBytes && result.content.length > options.maxBytes) {
         result.content = result.content.slice(0, options.maxBytes);
-        result.cost.tokens = Math.ceil(result.content.length / 4);
         result.contentTruncated = true;
       }
+      fitAndFinalize(result, options.maxBytes);
       // Decoders bypass scanning — they extract from structured sources.
       // Do NOT attach a findings field; preserve existing decoder envelope.
       return result;
@@ -193,48 +269,10 @@ export async function read(url: string, options: ReadOptions = {}): Promise<Read
     ...(findings !== undefined ? { findings } : {}),
   };
 
-  // maxBytes bounds the envelope: shrink links (halving) before touching content.
-  if (options.maxBytes) {
-    // cost.tokens is recomputed after shrinking; measure with its widest
-    // possible value so the final number never grows the envelope past
-    // the budget we just enforced.
-    envelope.cost.tokens = Math.ceil(options.maxBytes / 4);
-    while (
-      Buffer.byteLength(JSON.stringify(envelope), 'utf-8') > options.maxBytes &&
-      envelope.links.length > 0
-    ) {
-      const keep = Math.floor(envelope.links.length / 2);
-      envelope.linksOmitted = (envelope.linksOmitted ?? 0) + (envelope.links.length - keep);
-      envelope.links = envelope.links.slice(0, keep);
-    }
-
-    // Links exhausted but still over budget: binary-search the largest
-    // content prefix whose full envelope fits (issue #62). Byte-accurate —
-    // measured against the serialized envelope, not content length. Only
-    // fixed metadata larger than maxBytes itself can still overshoot.
-    if (
-      Buffer.byteLength(JSON.stringify(envelope), 'utf-8') > options.maxBytes &&
-      envelope.content.length > 0
-    ) {
-      const full = envelope.content;
-      const suffix = '... [truncated]';
-      // Set the signal BEFORE measuring so its own bytes are budgeted.
-      envelope.contentTruncated = true;
-      let lo = 0;
-      let hi = full.length;
-      while (lo < hi) {
-        const mid = (lo + hi + 1) >> 1;
-        envelope.content = full.slice(0, mid) + suffix;
-        if (Buffer.byteLength(JSON.stringify(envelope), 'utf-8') <= options.maxBytes) {
-          lo = mid;
-        } else {
-          hi = mid - 1;
-        }
-      }
-      envelope.content = full.slice(0, lo) + suffix;
-    }
-  }
-
-  envelope.cost = { tokens: Math.ceil(JSON.stringify(envelope).length / 4) };
+  // maxBytes bounds the envelope: shrink links (halving) before touching
+  // content. envelopeBytes is measured with a fixed-width placeholder so its
+  // own bytes are budgeted during the diet, then overwritten with the real
+  // serialized size (fitReadEnvelope also recomputes cost.tokens).
+  fitAndFinalize(envelope, options.maxBytes);
   return envelope;
 }

--- a/src/read/types.ts
+++ b/src/read/types.ts
@@ -42,8 +42,9 @@ export interface ReadResult {
   cost: { tokens: number };
   /** Actual serialized size of this envelope in bytes, recorded after the
    *  maxBytes diet runs. When maxBytes was set, this is ≤ maxBytes (modulo the
-   *  fixed-width placeholder used during measurement). Absent on the legacy
-   *  (scan: false) path. */
+   *  fixed-width placeholder used during measurement). Absent only on the
+   *  legacy non-decoder (scan: false) path — decoder URLs always run the
+   *  finalize helper regardless of the scan flag. */
   envelopeBytes?: number;
   /** Trap scanner findings. Present when the scanner ran. Absent when scan: false. */
   findings?: ReadFinding[];

--- a/src/read/types.ts
+++ b/src/read/types.ts
@@ -40,6 +40,11 @@ export interface ReadResult {
     siteName: string | null;
   };
   cost: { tokens: number };
+  /** Actual serialized size of this envelope in bytes, recorded after the
+   *  maxBytes diet runs. When maxBytes was set, this is ≤ maxBytes (modulo the
+   *  fixed-width placeholder used during measurement). Absent on the legacy
+   *  (scan: false) path. */
+  envelopeBytes?: number;
   /** Trap scanner findings. Present when the scanner ran. Absent when scan: false. */
   findings?: ReadFinding[];
 }

--- a/src/replay/envelope.ts
+++ b/src/replay/envelope.ts
@@ -1,0 +1,128 @@
+// src/replay/envelope.ts
+import { truncateResponse, type TruncationInfo } from './truncate.js';
+
+export interface CappedEnvelope<T> { envelope: T; envelopeBytes: number }
+
+const MIN_DATA_BUDGET = 512;
+/** Cap on truncate/build/serialize rounds during the budget bisection. */
+const MAX_ROUNDS = 8;
+
+/** Synthetic truncation info used only to size the skeleton (I2): the final
+ * envelope always carries a `truncated` block once we start capping, so the
+ * skeleton must include one or skeletonBytes under-counts the wrapper. */
+const SKELETON_INFO: TruncationInfo = {
+  originalBytes: 0,
+  finalBytes: 0,
+  droppedItems: 0,
+  keptItems: 0,
+  note: 'reduced to fit envelope budget',
+};
+
+function bytes(s: string): number {
+  return Buffer.byteLength(s, 'utf-8');
+}
+
+function appendNote(note: string | undefined, extra: string): string {
+  if (!extra) return note ?? '';
+  if (!note) return extra;
+  // Dedupe: multi-signal notes must carry each phrase once.
+  if (note === extra || note.endsWith(`; ${extra}`)) return note;
+  return `${note}; ${extra}`;
+}
+
+function mergeInfo(first: TruncationInfo | false, second: TruncationInfo): TruncationInfo {
+  const ENVELOPE_NOTE = 'reduced to fit envelope budget';
+  if (!first) {
+    // M3: keep second.note (e.g. schema-sample "fields dropped" signals).
+    return { ...second, note: appendNote(second.note, ENVELOPE_NOTE) };
+  }
+  // M3: combine BOTH notes, then append the dedupe phrase to the combined text.
+  const combined = second.note ? appendNote(first.note, second.note) : first.note;
+  return {
+    originalBytes: first.originalBytes,
+    finalBytes: second.finalBytes,
+    droppedItems: first.droppedItems + second.droppedItems,
+    keptItems: second.keptItems,
+    ...(first.droppedFields || second.droppedFields
+      ? { droppedFields: (first.droppedFields ?? 0) + (second.droppedFields ?? 0) }
+      : {}),
+    note: appendNote(combined, ENVELOPE_NOTE),
+  };
+}
+
+/**
+ * Ensure the SERIALIZED envelope fits maxBytes by re-truncating data.
+ *
+ * The envelope skeleton (status, metadata, truncation info) is never dropped:
+ * the data budget floors at MIN_DATA_BUDGET, so a pathological maxBytes smaller
+ * than the skeleton itself yields a slightly-over envelope with honest metadata.
+ *
+ * Convergence is by BISECTION on the data budget, measured against the REAL
+ * serialized output — not a fixed budget shave. A fixed shave caps out at a
+ * bounded reduction (e.g. 40%), but indented serialization inflates the data
+ * span 2-4x over the compact bytes truncateResponse targets, so a fixed shave
+ * exits still over budget on ordinary payloads. Bisection searches
+ * [MIN_DATA_BUDGET, maxBytes - skeletonBytes] for the largest data budget whose
+ * serialized envelope fits maxBytes: truncate from the original data, build,
+ * serialize, measure; if over, search lower; if under, keep the best-fitting
+ * result and search higher (retain as much data as possible). Bounded to
+ * MAX_ROUNDS truncate/serialize passes.
+ *
+ * The ONLY documented exception is the floor: if even MIN_DATA_BUDGET's
+ * envelope overshoots (skeleton alone exceeds maxBytes), that overshooting
+ * envelope is returned with honest metadata rather than dropping the skeleton.
+ *
+ * Placeholder caveat (grok P1-1): callers that patch a numeric `envelopeBytes`
+ * field into the envelope after this returns should seed a placeholder at least
+ * as wide as the final value's digit count. envelopeBytes here is the measured
+ * width of what `serialize` produced; a 9-digit placeholder (e.g. 999_999_999)
+ * only guarantees no width growth for maxBytes < 1e9 — fine in practice.
+ */
+export function capEnvelope<T>(
+  build: (data: unknown, truncated: TruncationInfo | false) => T,
+  data: unknown,
+  firstTruncation: TruncationInfo | false,
+  maxBytes: number | undefined,
+  serialize: (envelope: T) => string,
+): CappedEnvelope<T> {
+  const passthrough = build(data, firstTruncation);
+  const passthroughBytes = bytes(serialize(passthrough));
+  if (!maxBytes || passthroughBytes <= maxBytes) {
+    return { envelope: passthrough, envelopeBytes: passthroughBytes };
+  }
+
+  // Skeleton overhead: same serializer, data nulled out, truncated block
+  // present (I2). Exact for the wrapper (indent included) — no compact-vs-
+  // indented hybrid math (grok P1-1). The truncated block is always present
+  // in the final capped envelope, so include it here.
+  const skeletonBytes = bytes(serialize(build(null, SKELETON_INFO)));
+
+  interface Candidate { envelope: T; size: number }
+  const truncateAt = (budget: number): Candidate => {
+    const result = truncateResponse(data, { maxBytes: budget });
+    const info = result.truncated ? mergeInfo(firstTruncation, result.truncated) : firstTruncation;
+    const envelope = build(result.data, info);
+    return { envelope, size: bytes(serialize(envelope)) };
+  };
+
+  // Guaranteed fallback: the floor budget. May overshoot (documented exception).
+  let best = truncateAt(MIN_DATA_BUDGET);
+  let rounds = 1;
+
+  // Bisect for the largest data budget that still fits, keeping more data.
+  let lo = MIN_DATA_BUDGET + 1;
+  let hi = maxBytes - skeletonBytes;
+  while (lo <= hi && rounds < MAX_ROUNDS) {
+    const mid = Math.floor((lo + hi) / 2);
+    const cand = truncateAt(mid);
+    rounds++;
+    if (cand.size <= maxBytes) {
+      best = cand;      // fits — retain more data by searching higher
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;     // over budget — search lower
+    }
+  }
+
+  return { envelope: best.envelope, envelopeBytes: best.size };
+}

--- a/test/mcp/envelope-cap.test.ts
+++ b/test/mcp/envelope-cap.test.ts
@@ -1,0 +1,180 @@
+// test/mcp/envelope-cap.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer as createHttpServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { writeSkillFile } from '../../src/skill/store.js';
+import { signSkillFile } from '../../src/skill/signing.js';
+import { deriveSigningKey } from '../../src/auth/crypto.js';
+import { getMachineId } from '../../src/auth/manager.js';
+import type { SkillFile } from '../../src/types.js';
+import { createMcpServer } from '../../src/mcp.js';
+
+function makeSkill(domain: string, baseUrl: string, endpoints: Array<{ id: string; method: string; path: string; tier?: string }>): SkillFile {
+  return {
+    version: '1.2',
+    domain,
+    capturedAt: '2026-02-04T12:00:00.000Z',
+    baseUrl,
+    endpoints: endpoints.map(ep => ({
+      id: ep.id,
+      method: ep.method,
+      path: ep.path,
+      queryParams: {},
+      headers: {},
+      responseShape: { type: 'object', fields: ['id'] },
+      examples: {
+        request: { url: `${baseUrl}${ep.path}`, headers: {} },
+        responsePreview: null,
+      },
+      replayability: {
+        tier: (ep.tier ?? 'green') as 'green' | 'yellow' | 'orange' | 'red' | 'unknown',
+        verified: true,
+        signals: [],
+      },
+    })),
+    metadata: { captureCount: 1, filteredCount: 0, toolVersion: '0.5.0' },
+    provenance: 'self',
+  };
+}
+
+// A big payload — well over any reasonable maxBytes test cap.
+const bigItems = Array.from({ length: 500 }, (_, i) => ({
+  id: i,
+  title: `Item number ${i} with some extra padding text to inflate size`,
+  description: 'x'.repeat(200),
+}));
+
+describe('MCP envelope cap', () => {
+  let testDir: string;
+  let httpServer: Server;
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'apitap-mcp-envelope-cap-'));
+
+    httpServer = createHttpServer((req, res) => {
+      if (req.url === '/big') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(bigItems));
+      } else if (req.url === '/small') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ id: 1, title: 'small payload' }));
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    await new Promise<void>(resolve => httpServer.listen(0, resolve));
+    const port = (httpServer.address() as AddressInfo).port;
+    const baseUrl = `http://localhost:${port}`;
+
+    const machineId = await getMachineId();
+    const sigKey = deriveSigningKey(machineId);
+    // Skill domain must match baseUrl's hostname (validateSkillFile enforces
+    // this), so "localhost" is the only usable domain here — it also happens
+    // to be what apitap_browse resolves from a port-less "http://localhost/..." URL.
+    await writeSkillFile(signSkillFile(makeSkill('localhost', baseUrl, [
+      { id: 'get-big', method: 'GET', path: '/big', tier: 'green' },
+      { id: 'get-small', method: 'GET', path: '/small', tier: 'green' },
+    ]), sigKey), testDir);
+
+    const server = createMcpServer({ skillsDir: testDir, _skipSsrfCheck: true });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'test-client', version: '1.0.0' });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    cleanup = async () => {
+      await client.close();
+      await server.close();
+    };
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    await new Promise<void>(resolve => httpServer.close(() => resolve()));
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('apitap_replay caps content[0].text at maxBytes and reports envelopeBytes', async () => {
+    const result = await client.callTool({
+      name: 'apitap_replay',
+      arguments: { domain: 'localhost', endpointId: 'get-big', maxBytes: 4000 },
+    });
+    assert.equal(result.isError, undefined);
+    const text = (result.content as any)[0].text;
+    assert.ok(Buffer.byteLength(text) <= 4000, `payload ${Buffer.byteLength(text)} > 4000`);
+    const payload = JSON.parse(text);
+    assert.equal(typeof payload.envelopeBytes, 'number');
+    assert.ok(payload.truncated);
+  });
+
+  it('apitap_replay under budget still reports envelopeBytes without truncation', async () => {
+    const result = await client.callTool({
+      name: 'apitap_replay',
+      arguments: { domain: 'localhost', endpointId: 'get-small', maxBytes: 4000 },
+    });
+    assert.equal(result.isError, undefined);
+    const text = (result.content as any)[0].text;
+    const payload = JSON.parse(text);
+    assert.equal(typeof payload.envelopeBytes, 'number');
+    assert.equal(payload.truncated, undefined);
+    assert.equal(payload.data.title, 'small payload');
+  });
+
+  it('apitap_replay with no maxBytes omits envelope capping (no envelopeBytes)', async () => {
+    const result = await client.callTool({
+      name: 'apitap_replay',
+      arguments: { domain: 'localhost', endpointId: 'get-small' },
+    });
+    assert.equal(result.isError, undefined);
+    const text = (result.content as any)[0].text;
+    const payload = JSON.parse(text);
+    // capEnvelope always reports the measured size, even without a maxBytes ceiling.
+    assert.equal(typeof payload.envelopeBytes, 'number');
+    assert.equal(payload.truncated, undefined);
+  });
+
+  it('apitap_replay_batch caps each result independently and reports envelopeBytes per result', async () => {
+    const result = await client.callTool({
+      name: 'apitap_replay_batch',
+      arguments: {
+        requests: [
+          { domain: 'localhost', endpointId: 'get-big' },
+          { domain: 'localhost', endpointId: 'get-small' },
+        ],
+        maxBytes: 4000,
+      },
+    });
+    assert.equal(result.isError, undefined);
+    const text = (result.content as any)[0].text;
+    const results = JSON.parse(text);
+    assert.equal(results.length, 2);
+    for (const r of results) {
+      assert.equal(typeof r.envelopeBytes, 'number');
+    }
+    const bigResult = results.find((r: any) => r.endpointId === 'get-big');
+    assert.ok(bigResult.truncated, 'big result should be truncated');
+    const smallResult = results.find((r: any) => r.endpointId === 'get-small');
+    assert.equal(smallResult.truncated, undefined);
+  });
+
+  it('apitap_browse caps content[0].text at maxBytes and reports envelopeBytes', async () => {
+    const result = await client.callTool({
+      name: 'apitap_browse',
+      arguments: { url: 'http://localhost/big', maxBytes: 4000 },
+    });
+    assert.equal(result.isError, undefined);
+    const text = (result.content as any)[0].text;
+    assert.ok(Buffer.byteLength(text) <= 4000, `payload ${Buffer.byteLength(text)} > 4000`);
+    const payload = JSON.parse(text);
+    assert.equal(typeof payload.envelopeBytes, 'number');
+    assert.ok(payload.truncated);
+  });
+});

--- a/test/read/envelope-diet.test.ts
+++ b/test/read/envelope-diet.test.ts
@@ -16,7 +16,30 @@ describe('read envelope diet', () => {
   let base: string;
 
   before(async () => {
+    // Firebase-style routes for the HN decoder fixture: one item with ~50 KB
+    // of body text so the decoder path must engage the envelope diet.
+    const bigText = 'Decoder content that must be capped. '.repeat(1400); // ~52 KB
+    const firebaseRoutes: Record<string, unknown> = {
+      '/v0/item/12345.json': {
+        id: 12345,
+        title: 'Big decoder story',
+        by: 'testuser',
+        score: 150,
+        text: bigText,
+        type: 'story',
+        time: 1700000000,
+        kids: [],
+        descendants: 0,
+      },
+    };
+
     server = createServer((req, res) => {
+      const firebase = firebaseRoutes[req.url ?? ''];
+      if (firebase) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(firebase));
+        return;
+      }
       res.writeHead(200, { 'content-type': 'text/html' });
       if (req.url === '/big') {
         // Large content, zero links: link shrinking cannot rescue the envelope.
@@ -31,6 +54,16 @@ describe('read envelope diet', () => {
   });
 
   after(() => server.close());
+
+  // Fixture helpers — generic HTML read and HN-style decoder read.
+  const readWithFixture = (opts: { maxBytes?: number } = {}) =>
+    read(`${base}/page`, { skipSsrf: true, ...opts });
+  const readDecoderFixture = (opts: { maxBytes?: number } = {}) =>
+    read('https://news.ycombinator.com/item?id=12345', {
+      skipSsrf: true,
+      _apiBaseUrl: base,
+      ...opts,
+    });
 
   it('dedupes links by href and caps at 100 with linksOmitted', async () => {
     const result = await read(`${base}/page`, { skipSsrf: true });
@@ -82,6 +115,25 @@ describe('read envelope diet', () => {
     const result = await read(`${base}/big`, { skipSsrf: true, maxBytes: 100_000 });
     assert.ok(result);
     assert.strictEqual(result.contentTruncated, undefined);
+  });
+
+  it('read envelope reports envelopeBytes matching its serialized size', async () => {
+    const result = await readWithFixture({ maxBytes: 5000 });
+    assert.ok(result);
+    assert.equal(typeof result.envelopeBytes, 'number');
+    const measured = Buffer.byteLength(JSON.stringify(result), 'utf-8');
+    // envelopeBytes was measured with a fixed-width placeholder — allow ±16 bytes
+    assert.ok(Math.abs(measured - result.envelopeBytes!) <= 16, `${measured} vs ${result.envelopeBytes}`);
+    assert.ok(result.envelopeBytes! <= 5000 + 16);
+  });
+
+  it('DECODER results are envelope-capped too (grok P0-1 regression test)', async () => {
+    const result = await readDecoderFixture({ maxBytes: 4000 });
+    assert.ok(result);
+    const measured = Buffer.byteLength(JSON.stringify(result), 'utf-8');
+    assert.ok(measured <= 4000 + 16, `decoder envelope ${measured} > 4000`);
+    assert.equal(result.contentTruncated, true);
+    assert.equal(typeof result.envelopeBytes, 'number');
   });
 
   it('scan:false keeps the legacy envelope (no diet)', async () => {

--- a/test/replay/envelope-cli.test.ts
+++ b/test/replay/envelope-cli.test.ts
@@ -1,0 +1,169 @@
+// test/replay/envelope-cli.test.ts
+// Verifies `apitap replay --json --max-bytes N` and `apitap browse --json --max-bytes N`
+// hard-cap stdout at N bytes via capEnvelope, and that the envelope always carries
+// a numeric `envelopeBytes` sibling of `truncated` when --json is used.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { writeSkillFile } from '../../src/skill/store.js';
+import { signSkillFile } from '../../src/skill/signing.js';
+import { deriveSigningKey } from '../../src/auth/crypto.js';
+import { getMachineId } from '../../src/auth/manager.js';
+import type { SkillFile } from '../../src/types.js';
+
+const execFileAsync = promisify(execFile);
+
+interface CliResult { stdout: string; stderr: string; code: number }
+
+async function runCli(args: string[], env: Record<string, string>): Promise<CliResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      'node',
+      ['--import', 'tsx', 'src/cli.ts', ...args],
+      { env: { ...process.env, ...env }, timeout: 20_000 },
+    );
+    return { stdout, stderr, code: 0 };
+  } catch (err: any) {
+    return { stdout: err.stdout ?? '', stderr: err.stderr ?? '', code: typeof err.code === 'number' ? err.code : 1 };
+  }
+}
+
+describe('CLI envelope cap on replay/browse --json', () => {
+  let testDir: string;
+  let skillsDir: string;
+  let server: Server;
+  let baseUrl: string;
+  let domain: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'apitap-envelope-cli-'));
+    skillsDir = join(testDir, 'skills');
+    await mkdir(skillsDir, { recursive: true });
+
+    server = createServer((req, res) => {
+      if (req.url === '/big') {
+        // ~200 KB JSON array — comfortably over any small --max-bytes budget.
+        const items = Array.from({ length: 4000 }, (_, i) => ({
+          id: i,
+          name: `item-${i}`,
+          description: 'x'.repeat(30),
+        }));
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(items));
+      } else if (req.url === '/small') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, id: 1 }));
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+    domain = '127.0.0.1';
+
+    const skill: SkillFile = {
+      version: '1.2',
+      domain,
+      baseUrl,
+      capturedAt: new Date().toISOString(),
+      endpoints: [
+        {
+          id: 'get-big',
+          method: 'GET',
+          path: '/big',
+          queryParams: {},
+          headers: {},
+          responseShape: { type: 'array' },
+          examples: { request: { url: `${baseUrl}/big`, headers: {} }, responsePreview: null },
+          confidence: 0.6,
+          endpointProvenance: 'skeleton',
+          replayability: { tier: 'green', verified: true, signals: [] },
+        } as any,
+        {
+          id: 'get-small',
+          method: 'GET',
+          path: '/small',
+          queryParams: {},
+          headers: {},
+          responseShape: { type: 'object' },
+          examples: { request: { url: `${baseUrl}/small`, headers: {} }, responsePreview: null },
+          confidence: 0.6,
+          endpointProvenance: 'skeleton',
+          replayability: { tier: 'green', verified: true, signals: [] },
+        } as any,
+      ],
+      metadata: { captureCount: 0, filteredCount: 0, toolVersion: '1.0.0' },
+      provenance: 'self',
+    };
+    const machineId = await getMachineId();
+    const signingKey = deriveSigningKey(machineId);
+    await writeSkillFile(signSkillFile(skill, signingKey), skillsDir);
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  const fixtureEnv = () => ({
+    APITAP_DIR: testDir,
+    APITAP_SKILLS_DIR: skillsDir,
+  });
+
+  it('replay --json --max-bytes N emits at most N bytes of stdout', async () => {
+    const { stdout, code } = await runCli(
+      ['replay', domain, 'get-big', '--danger-disable-ssrf', '--json', '--max-bytes', '4000'],
+      fixtureEnv(),
+    );
+    assert.equal(code, 0);
+    const parsed = JSON.parse(stdout);
+    assert.ok(Buffer.byteLength(stdout.trim()) <= 4000, `stdout ${Buffer.byteLength(stdout)} > 4000`);
+    assert.equal(typeof parsed.envelopeBytes, 'number');
+    assert.ok(parsed.truncated);
+  });
+
+  it('under-budget replay still reports envelopeBytes', async () => {
+    const { stdout, code } = await runCli(
+      ['replay', domain, 'get-small', '--danger-disable-ssrf', '--json', '--max-bytes', '50000'],
+      fixtureEnv(),
+    );
+    assert.equal(code, 0);
+    const parsed = JSON.parse(stdout);
+    assert.equal(typeof parsed.envelopeBytes, 'number');
+    assert.equal(parsed.truncated, undefined);
+  });
+
+  it('browse --json --max-bytes N emits at most N bytes of stdout', async () => {
+    const { stdout, code } = await runCli(
+      ['browse', `${baseUrl}/big`, '--danger-disable-ssrf', '--json', '--max-bytes', '4000'],
+      fixtureEnv(),
+    );
+    assert.equal(code, 0);
+    const parsed = JSON.parse(stdout);
+    assert.ok(Buffer.byteLength(stdout.trim()) <= 4000, `stdout ${Buffer.byteLength(stdout)} > 4000`);
+    assert.equal(parsed.success, true);
+    assert.equal(typeof parsed.envelopeBytes, 'number');
+    assert.ok(parsed.truncated);
+  });
+
+  it('under-budget browse still reports envelopeBytes', async () => {
+    const { stdout, code } = await runCli(
+      ['browse', `${baseUrl}/small`, '--danger-disable-ssrf', '--json', '--max-bytes', '50000'],
+      fixtureEnv(),
+    );
+    assert.equal(code, 0);
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.success, true);
+    assert.equal(typeof parsed.envelopeBytes, 'number');
+    assert.equal(parsed.truncated, undefined);
+  });
+});

--- a/test/replay/envelope.test.ts
+++ b/test/replay/envelope.test.ts
@@ -1,0 +1,129 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { capEnvelope } from '../../src/replay/envelope.js';
+import type { TruncationInfo } from '../../src/replay/truncate.js';
+
+type Env = { status: number; data: unknown; truncated?: TruncationInfo | false; meta: string };
+const build = (data: unknown, truncated: TruncationInfo | false): Env =>
+  ({ status: 200, data, ...(truncated ? { truncated } : {}), meta: 'x'.repeat(200) });
+const ser = (e: Env) => JSON.stringify(e, null, 2);
+const serCompact = (e: Env) => JSON.stringify(e);
+
+describe('capEnvelope', () => {
+  it('no maxBytes: passes through and reports envelopeBytes', () => {
+    const { envelope, envelopeBytes } = capEnvelope(build, { a: 1 }, false, undefined, ser);
+    assert.deepEqual(envelope.data, { a: 1 });
+    assert.equal(envelopeBytes, Buffer.byteLength(ser(envelope)));
+  });
+
+  it('under budget: unchanged data, accurate envelopeBytes', () => {
+    const { envelope, envelopeBytes } = capEnvelope(build, { a: 1 }, false, 10_000, ser);
+    assert.deepEqual(envelope.data, { a: 1 });
+    assert.ok(envelopeBytes <= 10_000);
+  });
+
+  it('over budget: re-truncates data until serialized envelope fits', () => {
+    const bigData = Array.from({ length: 500 }, (_, i) => ({ i, pad: 'y'.repeat(100) }));
+    const { envelope, envelopeBytes } = capEnvelope(build, bigData, false, 4_000, ser);
+    assert.ok(envelopeBytes <= 4_000, `envelope ${envelopeBytes} > 4000`);
+    assert.equal(Buffer.byteLength(ser(envelope)), envelopeBytes);
+    assert.ok(envelope.truncated && envelope.truncated.droppedItems > 0);
+  });
+
+  it('merges first-pass truncation info: originalBytes preserved, note appended', () => {
+    const first: TruncationInfo = { originalBytes: 4_624_971, finalBytes: 7_000, droppedItems: 68, keptItems: 1 };
+    const stillBig = Array.from({ length: 60 }, (_, i) => ({ i, pad: 'z'.repeat(100) }));
+    const { envelope } = capEnvelope(build, stillBig, first, 3_000, ser);
+    assert.ok(envelope.truncated);
+    assert.equal(envelope.truncated.originalBytes, 4_624_971);
+    assert.match(envelope.truncated.note ?? '', /envelope/);
+  });
+
+  it('floors data budget at 512: tiny maxBytes yields envelope skeleton, may overshoot', () => {
+    const bigData = Array.from({ length: 100 }, () => 'w'.repeat(200));
+    const { envelope } = capEnvelope(build, bigData, false, 200, ser);
+    // skeleton fields survive even though 200 bytes is impossible
+    assert.equal(envelope.status, 200);
+    assert.ok(envelope.truncated);
+  });
+
+  // Test addendum (grok P1-1): the cap must hold under BOTH serializers — the
+  // indented CLI form (JSON.stringify(e, null, 2)) and the compact MCP form
+  // (JSON.stringify(e)) — for a nested-array (gamma-class) payload. The
+  // indented form is the adversarial case: skeletonBytes cannot see indent
+  // inflation inside the data span, so this proves the shave-per-iteration and
+  // no-progress terminator actually converge.
+  describe('both serializers hold the cap (nested-array payload)', () => {
+    // Gamma-class nested-array payload: full envelope is ~46 KB, ~6x the 8 KB
+    // budget, forcing heavy re-truncation. The indented form is the adversarial
+    // case (indent inflates the data span that skeletonBytes cannot see).
+    const MAX = 8_000;
+    const nested = Array.from({ length: 40 }, (_, i) => ({
+      i,
+      rows: Array.from({ length: 10 }, (_, j) => ({ j, pad: 'q'.repeat(50) })),
+    }));
+
+    for (const [name, s] of [['indented', ser], ['compact', serCompact]] as const) {
+      it(`${name}: envelopeBytes <= maxBytes`, () => {
+        const { envelope, envelopeBytes } = capEnvelope(build, nested, false, MAX, s);
+        assert.ok(envelopeBytes <= MAX, `${name} envelope ${envelopeBytes} > ${MAX}`);
+        assert.equal(Buffer.byteLength(s(envelope)), envelopeBytes);
+        assert.ok(envelope.truncated && envelope.truncated.droppedItems > 0);
+      });
+    }
+
+    it('indented: merge path also holds the cap', () => {
+      const first: TruncationInfo = { originalBytes: 9_000_000, finalBytes: 40_000, droppedItems: 500, keptItems: 3 };
+      const { envelope, envelopeBytes } = capEnvelope(build, nested, first, MAX, ser);
+      assert.ok(envelopeBytes <= MAX, `indented merge envelope ${envelopeBytes} > ${MAX}`);
+      assert.equal(envelope.truncated && envelope.truncated.originalBytes, 9_000_000);
+      assert.match(envelope.truncated ? (envelope.truncated.note ?? '') : '', /envelope/);
+    });
+  });
+
+  // Plateau case: this payload/budget combo tripped the (now-removed) eager
+  // no-progress break and overshot the cap by ~6% under the indented serializer.
+  // With the escalating-budget loop it must now fit — the harder budget of a
+  // later iteration breaks through truncateResponse's step-function plateau.
+  it('plateau payload that once overshot ~6% now fits under indented serializer', () => {
+    const plateau = Array.from({ length: 80 }, (_, i) => ({ i, rows: Array.from({ length: 20 }, (_, j) => ({ j, pad: 'q'.repeat(60) })) }));
+    const { envelope, envelopeBytes } = capEnvelope(build, plateau, false, 5_000, ser);
+    assert.ok(envelopeBytes <= 5_000, `plateau envelope ${envelopeBytes} > 5000`);
+    assert.equal(Buffer.byteLength(ser(envelope)), envelopeBytes);
+    assert.ok(envelope.truncated && envelope.truncated.droppedItems > 0);
+  });
+
+  it('merged note carries the envelope-budget phrase exactly once after multiple rounds', () => {
+    const first: TruncationInfo = { originalBytes: 9_000_000, finalBytes: 40_000, droppedItems: 500, keptItems: 3 };
+    const stillBig = Array.from({ length: 80 }, (_, i) => ({ i, rows: Array.from({ length: 20 }, (_, j) => ({ j, pad: 'q'.repeat(60) })) }));
+    const { envelope } = capEnvelope(build, stillBig, first, 5_000, ser);
+    const note = envelope.truncated ? (envelope.truncated.note ?? '') : '';
+    const occurrences = note.match(/reduced to fit envelope budget/g) ?? [];
+    assert.equal(occurrences.length, 1, `phrase appeared ${occurrences.length}x in note: ${note}`);
+  });
+
+  // M4: adversarial payloads the fixed-shave loop failed to cap. Indented
+  // serialization inflates the data span 2-4x over the compact bytes
+  // truncateResponse targets, so a bounded shave exited over budget. Bisection
+  // on measured serialized bytes must hold the cap for all three.
+  describe('adversarial indent-inflation payloads hold the cap (indented serializer)', () => {
+    const deepNest = (depth: number, breadth: number): unknown =>
+      depth === 0
+        ? { pad: 'q'.repeat(40) }
+        : { k: Array.from({ length: breadth }, () => deepNest(depth - 1, breadth)) };
+
+    const cases: [string, unknown, number][] = [
+      ['flat 3000-int array @ 3000', Array.from({ length: 3000 }, (_, i) => i), 3_000],
+      ['depth-6 breadth-3 nest @ 6000', deepNest(6, 3), 6_000],
+      ['depth-5 breadth-4 nest @ 5000', deepNest(5, 4), 5_000],
+    ];
+
+    for (const [name, payload, max] of cases) {
+      it(`${name}: envelopeBytes <= maxBytes`, () => {
+        const { envelope, envelopeBytes } = capEnvelope(build, payload, false, max, ser);
+        assert.ok(envelopeBytes <= max, `${name} envelope ${envelopeBytes} > ${max}`);
+        assert.equal(Buffer.byteLength(ser(envelope)), envelopeBytes);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Gauntlet P1: `--max-bytes 4000` produced ~16 KB of stdout — `maxBytes` budgeted only the data payload, and envelope overhead (metadata, truncation info, contract warnings, JSON indent) rode on top uncounted.

## What

**`maxBytes` now bounds the full serialized response** on `replay`, `replay_batch` (per result), `browse`, and `read` — CLI `--json` and MCP alike — and every capped response reports `envelopeBytes`, its actual serialized size.

- **`capEnvelope`** (`src/replay/envelope.ts`): bisects the data budget against the *measured* serialization (indented for CLI, compact for MCP), keeping the largest fitting result. Floor: the data budget never drops below 512 bytes and the envelope skeleton (status, metadata, truncation info, warnings) is never dropped, so a budget smaller than the irreducible envelope yields an honest, bounded overshoot instead of dropped fields.
- **Read path**: the v2.0.1 re-slice loop is extracted into `fitReadEnvelope` and — the important fix — now applies to **site-decoder results too** (Wikipedia/HN/…), which previously bypassed the envelope diet entirely via an early return with only a char-slice.
- `envelopeBytes` is always present in `--json`/MCP output as a sibling of `truncated` (top-level on read); MCP tool descriptions and README updated.

## Real-store numbers

The gauntlet's headline case, `replay gamma-api.polymarket.com get-events --json --max-bytes 4000`:
- before: **~16,000** bytes of stdout
- after: **4,512** bytes — this specific payload is a documented floor case (a single item that truncation cannot shrink below ~2.2 KB compact, plus 11 never-dropped contractWarnings), reported honestly via `envelopeBytes` and the truncation note

Wikipedia read at `--max-bytes 4000`: `envelopeBytes: 905`, hard-capped.

## Tests

1710 passing (+17: capEnvelope unit incl. adversarial indented payloads that defeated two earlier soft-cap algorithms, CLI byte-cap E2E, MCP per-surface caps, decoder-cap regression), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQaJk5nQXmddqC2P4ZQrVz