### PR TITLE
fix(auth): the login handoff no longer wipes the session it just captured

### DIFF
--- a/src/auth/handoff.ts
+++ b/src/auth/handoff.ts
@@ -7,6 +7,14 @@ export interface HandoffOptions {
   domain: string;
   loginUrl?: string;        // URL to navigate to (defaults to https://<domain>)
   timeout?: number;          // ms, default 300000 (5 minutes)
+  /**
+   * @internal Run the handoff browser headless — for tests only, and refused
+   * outside a test run. A real handoff is a human logging in, so it is always
+   * headed; a headless one would sit invisibly waiting for input that can
+   * never come. Without this the flow cannot be exercised on a machine with
+   * no display.
+   */
+  _headless?: boolean;
 }
 
 export interface HandoffResult {
@@ -170,6 +178,21 @@ const handoffLocks = new Map<string, Promise<HandoffResult>>();
  * This avoids false positives from cookie-based heuristics that fire on
  * anonymous session cookies set during normal page load.
  */
+/**
+ * The handoff is a human logging in at a visible window, so headless is a
+ * test-only affordance. Mirrors assertSsrfBypassAllowed: an internal flag
+ * that would change security-relevant behaviour is refused outside a test
+ * run rather than trusted to stay internal by comment alone.
+ */
+function assertHeadlessHandoffAllowed(flag: unknown): void {
+  if (!flag) return;
+  if (process.env.NODE_TEST_CONTEXT || process.env.NODE_ENV === 'test') return;
+  throw new Error(
+    'Headless login handoff (_headless) is test-only and refused outside a test run — ' +
+    'a real handoff needs a visible window for the human to log in',
+  );
+}
+
 export async function requestAuth(
   authManager: AuthManager,
   options: HandoffOptions,
@@ -198,7 +221,8 @@ async function doHandoff(
   const loginUrl = options.loginUrl || `https://${domain}`;
   const timeout = options.timeout ?? 300_000; // 5 minutes
 
-  const { browser, context } = await launchBrowser({ headless: false });
+  assertHeadlessHandoffAllowed(options._headless);
+  const { browser, context } = await launchBrowser({ headless: options._headless === true });
 
   try {
 
@@ -323,15 +347,18 @@ async function doHandoff(
       };
     }
 
-    // Store session cookies
     const session: StoredSession = {
       cookies,
       savedAt: new Date().toISOString(),
       maxAgeMs: 24 * 60 * 60 * 1000, // 24 hours
     };
-    await authManager.storeSession(domain, session);
 
-    // Store OAuth credentials if detected during auth flow
+    // ORDER MATTERS: authManager.store() replaces the whole record, while
+    // storeSession/storeOAuthCredentials merge into it. The credential goes
+    // in first and the sidecars after — the other way round, store() wiped
+    // the session (and the OAuth refresh token) that had just been saved,
+    // so the next handoff's warm start found nothing and the human had to
+    // log in again.
     if (detectedOAuth) {
       detectedAuth = {
         type: 'bearer',
@@ -342,12 +369,6 @@ async function doHandoff(
         } : {}),
       };
       authDetected = 'bearer';
-
-      if (detectedOAuth.refreshToken) {
-        await authManager.storeOAuthCredentials(domain, {
-          refreshToken: detectedOAuth.refreshToken,
-        });
-      }
     }
 
     // Store detected auth header if found
@@ -370,6 +391,14 @@ async function doHandoff(
           value: cookieHeader,
         });
       }
+    }
+
+    // Sidecars last — see the ORDER MATTERS note above.
+    await authManager.storeSession(domain, session);
+    if (detectedOAuth?.refreshToken) {
+      await authManager.storeOAuthCredentials(domain, {
+        refreshToken: detectedOAuth.refreshToken,
+      });
     }
 
     return {

--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -21,7 +21,17 @@ export class AuthManager {
     this.authPath = join(baseDir, AUTH_FILENAME);
   }
 
-  /** Store auth credentials for a domain (overwrites existing). */
+  /**
+   * Store auth credentials for a domain, replacing the ENTIRE record —
+   * including the sidecars other writers manage (`session`, `tokens`,
+   * `refreshToken`, `clientSecret`). That is deliberate: a new credential
+   * may belong to a different identity, so silently keeping the previous
+   * one's session or OAuth secret beside it would be worse than losing them.
+   *
+   * The consequence for callers: write the credential FIRST, then the
+   * sidecars (`storeSession`, `storeTokens`, `storeOAuthCredentials` all
+   * merge). Doing it the other way round drops what you just saved.
+   */
   async store(domain: string, auth: StoredAuth): Promise<void> {
     const allAuth = await this.loadAll();
     allAuth[domain] = auth;

--- a/test/auth/manager.test.ts
+++ b/test/auth/manager.test.ts
@@ -143,6 +143,46 @@ describe('AuthManager token storage', () => {
     assert.equal(tokens?.csrf_token.value, 'new-token', 'tokens should be updated');
   });
 
+  it('store() replaces the whole record, sidecars included', async () => {
+    // Deliberate: a new credential may belong to a different identity, so the
+    // previous one's session and OAuth secret must not survive beside it.
+    // The cost is an ordering rule for callers — credential first, sidecars
+    // after — which the login handoff had backwards (it saved the session,
+    // then wiped it with store()). Pinning the semantics here so the fix
+    // cannot be "corrected" back into implicit preservation.
+    await manager.storeSession('example.com', {
+      cookies: [{ name: 'session', value: 'xyz', domain: 'example.com', path: '/' }],
+      savedAt: '2026-02-04T00:00:00Z',
+    });
+    await manager.storeOAuthCredentials('example.com', { refreshToken: 'rt-old-identity' });
+
+    await manager.store('example.com', {
+      type: 'bearer', header: 'authorization', value: 'Bearer new-identity',
+    });
+
+    assert.equal(await manager.retrieveSession('example.com'), null,
+      "store() must not keep the previous identity's session");
+    const oauth = await manager.retrieveOAuthCredentials('example.com');
+    assert.ok(!oauth?.refreshToken, "store() must not keep the previous identity's refresh token");
+    assert.equal((await manager.retrieve('example.com'))?.value, 'Bearer new-identity');
+  });
+
+  it('keeps both when the credential is written before the sidecars', async () => {
+    // The supported order, and what the handoff now does.
+    await manager.store('example.com', {
+      type: 'cookie', header: 'cookie', value: 'session=xyz',
+    });
+    await manager.storeSession('example.com', {
+      cookies: [{ name: 'session', value: 'xyz', domain: 'example.com', path: '/' }],
+      savedAt: '2026-02-04T00:00:00Z',
+    });
+    await manager.storeOAuthCredentials('example.com', { refreshToken: 'rt-1' });
+
+    assert.equal((await manager.retrieveSession('example.com'))?.cookies[0].value, 'xyz');
+    assert.equal((await manager.retrieveOAuthCredentials('example.com'))?.refreshToken, 'rt-1');
+    assert.equal((await manager.retrieve('example.com'))?.value, 'session=xyz');
+  });
+
   it('should list domains with auth', async () => {
     await manager.store('example.com', { type: 'bearer', header: 'authorization', value: 'xyz' });
     await manager.storeTokens('other.com', { csrf: { value: 'abc', refreshedAt: '' } });

--- a/test/e2e/auth-handoff.test.ts
+++ b/test/e2e/auth-handoff.test.ts
@@ -1,0 +1,211 @@
+// test/e2e/auth-handoff.test.ts
+// Live browser login handoff → encrypted session storage → replay with the
+// captured session. This is the apitap_auth_request path end to end; the
+// existing handoff tests only cover the detection helpers on synthetic
+// headers, so nothing exercised launch → sniff → store → inject before this.
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { requestAuth } from '../../src/auth/handoff.js';
+import { replayEndpoint } from '../../src/replay/engine.js';
+import { AuthManager } from '../../src/auth/manager.js';
+import type { SkillFile } from '../../src/types.js';
+
+const SESSION_VALUE = 'sess-e2e-abc123';
+
+describe('E2E: browser login handoff → stored session → authenticated replay', () => {
+  let server: Server;
+  let port: number;
+  let baseUrl: string;
+  let testDir: string;
+  let authManager: AuthManager;
+  /** Cookie header the fixture saw on its last /api/me call — the proof replay injected it. */
+  let lastApiCookie: string | undefined;
+
+  before(async () => {
+    server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = req.url ?? '/';
+
+      // The login page. A human would type credentials here; the page does it
+      // on load so the flow runs unattended — what is under test is ApiTap's
+      // side of the handoff, not form-filling.
+      if (req.method === 'GET' && url === '/login') {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`
+          <html><body><h1>Fixture login</h1>
+          <script>
+            fetch('/session', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ user: 'testuser', pass: 'hunter2' }),
+            }).then(() => fetch('/api/me'));
+          </script>
+          </body></html>
+        `);
+        return;
+      }
+
+      // Successful login: hand back a session cookie, exactly as a real
+      // login endpoint would.
+      if (req.method === 'POST' && url === '/session') {
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Set-Cookie': `session_id=${SESSION_VALUE}; Path=/; HttpOnly`,
+        });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+
+      // The private endpoint replay will later call with the stored session.
+      if (req.method === 'GET' && url === '/api/me') {
+        lastApiCookie = req.headers.cookie;
+        if (!req.headers.cookie?.includes(`session_id=${SESSION_VALUE}`)) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'not logged in' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ user: 'testuser', private: true }));
+        return;
+      }
+
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>(r => server.listen(0, '127.0.0.1', r));
+    port = (server.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>(r => server.close(() => r()));
+  });
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'apitap-handoff-e2e-'));
+    authManager = new AuthManager(testDir, 'test-machine-id-handoff');
+    lastApiCookie = undefined;
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  function meSkill(): SkillFile {
+    return {
+      version: '1.2',
+      domain: '127.0.0.1',
+      capturedAt: new Date().toISOString(),
+      baseUrl,
+      endpoints: [{
+        id: 'get-api-me',
+        method: 'GET',
+        path: '/api/me',
+        queryParams: {},
+        headers: {},
+        responseShape: { type: 'object', fields: ['user'] },
+        examples: {
+          request: { url: `${baseUrl}/api/me`, headers: {} },
+          responsePreview: null,
+        },
+        replayability: { tier: 'green', verified: true, signals: [] },
+      }],
+      metadata: { captureCount: 1, filteredCount: 0, toolVersion: '1.0.0' },
+      provenance: 'self' as const,
+    };
+  }
+
+  it('captures the session from a real browser login and replays with it', async () => {
+    // A real handoff ends when the human closes the window; unattended, the
+    // timeout is the exit. Either way the same capture-and-store code runs.
+    const result = await requestAuth(authManager, {
+      domain: '127.0.0.1',
+      loginUrl: `${baseUrl}/login`,
+      timeout: 6000,
+      _headless: true,
+    });
+
+    assert.equal(result.success, true, `handoff failed: ${result.error}`);
+    assert.ok(result.cookieCount > 0, 'handoff captured no cookies');
+    assert.equal(result.authDetected, 'cookie');
+
+    // The session is on disk, encrypted, and retrievable.
+    const session = await authManager.retrieveSession('127.0.0.1');
+    assert.ok(session, 'no session stored for the domain');
+    assert.ok(
+      session.cookies.some(c => c.name === 'session_id' && c.value === SESSION_VALUE),
+      'stored session is missing the login cookie',
+    );
+
+    // The payoff: replay reaches the private endpoint using only what the
+    // handoff stored — no cookie is passed here.
+    const replayed = await replayEndpoint(meSkill(), 'get-api-me', {
+      authManager,
+      domain: '127.0.0.1',
+      _skipSsrfCheck: true,
+    });
+
+    assert.equal(replayed.status, 200, `replay was not authenticated: ${JSON.stringify(replayed.data)}`);
+    assert.deepEqual(replayed.data, { user: 'testuser', private: true });
+    assert.match(lastApiCookie ?? '', new RegExp(`session_id=${SESSION_VALUE}`));
+  });
+
+  it('does not authenticate replay when no handoff has run', async () => {
+    // Guards the test above against passing for the wrong reason: without a
+    // stored session the same replay must come back 401.
+    const replayed = await replayEndpoint(meSkill(), 'get-api-me', {
+      authManager,
+      domain: '127.0.0.1',
+      _skipSsrfCheck: true,
+    });
+
+    assert.equal(replayed.status, 401);
+  });
+
+  it('leaves the session where the next handoff will warm-start from it', async () => {
+    // The user-facing failure this whole test file exists for: doHandoff
+    // opens by calling retrieveSessionWithFallback to restore cookies, so a
+    // session lost at write time means the human logs in again. Assert the
+    // exact lookup that warm start performs, not just the raw record.
+    await requestAuth(authManager, {
+      domain: '127.0.0.1',
+      loginUrl: `${baseUrl}/login`,
+      timeout: 6000,
+      _headless: true,
+    });
+
+    const warmStart = await authManager.retrieveSessionWithFallback('127.0.0.1');
+    assert.ok(warmStart, 'warm start would find no session — the human would have to log in again');
+    assert.ok(
+      warmStart.cookies.some(c => c.name === 'session_id' && c.value === SESSION_VALUE),
+      'warm-start session is missing the login cookie',
+    );
+
+    const stored = await authManager.retrieve('127.0.0.1');
+    assert.ok(stored, 'handoff stored no replayable auth');
+    assert.equal(stored.type, 'cookie');
+    assert.match(stored.value ?? '', new RegExp(SESSION_VALUE));
+  });
+
+  it('writes the captured credentials to disk encrypted', async () => {
+    // Credentials never land in a skill file, and the store they do land in
+    // is unreadable at rest.
+    await requestAuth(authManager, {
+      domain: '127.0.0.1',
+      loginUrl: `${baseUrl}/login`,
+      timeout: 6000,
+      _headless: true,
+    });
+
+    const raw = await readFile(join(testDir, 'auth.enc'));
+    assert.ok(raw.length > 0, 'no auth store was written');
+    assert.ok(
+      !raw.toString('binary').includes(SESSION_VALUE),
+      'session value is readable in plaintext on disk',
+    );
+  });
+});


### PR DESCRIPTION
## The bug

`doHandoff` called `storeSession(domain, session)` and then, once it had classified the credential, `store(domain, auth)`. `store()` replaces the whole record, so it dropped the session it had just saved — and the OAuth refresh token from `storeOAuthCredentials` on that path too. The next handoff's warm start (`retrieveSessionWithFallback`, the first thing `doHandoff` does) then found nothing, so the human logged in again for no reason.

Confirmed live on the published 2.2.1: a real Hermes agent ran `apitap_auth_request` against a fixture login site, a human logged in through the browser, and the tool correctly returned `{"success":true,"cookieCount":1,"authDetected":"cookie"}` — but `apitap auth 127.0.0.1 --json` then showed `hasHeaderAuth: true`, **`hasSession: false`**.

## How it was found

By writing the first end-to-end test of the `apitap_auth_request` path — browser launch → network sniff → encrypted storage → replay injection. Nothing covered that chain before; `test/auth/handoff.test.ts` only exercises the detection helpers against synthetic headers.

## The fix

Ordering, not new storage semantics: the credential is written first, the merging sidecar writers (`storeSession`, `storeOAuthCredentials`) after.

A first attempt made `store()` preserve sidecars implicitly. A grok review pointed out that keeps a **previous identity's** session and OAuth secret beside a new credential on every re-auth path (capture finish, native-host, cdp-attach) — worse than the bug. So `store()` keeps its full-replace semantics, now documented, including the ordering rule callers must follow.

Also adds `_headless` to `HandoffOptions` so the flow is testable without a display, refused outside a test run the same way `assertSsrfBypassAllowed` refuses an SSRF bypass.

## Tests

Four e2e cases (capture + authenticated replay, an un-authenticated control so the first can't pass for the wrong reason, the warm-start lookup, and credentials encrypted at rest) plus two unit tests pinning `store()`'s replace semantics and the supported write order. Both e2e regressions verified failing against the original ordering. 1785/1785, typecheck clean, new test stable across three runs.

## Not included

`browse` suggests `apitap auth request <domain>` on `user_denied`, but there is no such CLI subcommand — the handoff is MCP-only (`apitap_auth_request`). Worth a follow-up: either add the subcommand or fix the suggestion string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L2C9ys5cri7JeTyCi4Fv2