### PR TITLE
fix(cli): add `auth request` subcommand instead of silently parsing it as a domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,10 @@ apitap auth api.example.com
 # List all domains with stored auth
 apitap auth --list
 
+# Open a browser so a human can sign in, then store the session
+# (close the browser window when done — that is the "finished" signal)
+apitap auth request api.example.com
+
 # Refresh expired tokens via browser
 apitap refresh api.example.com
 
@@ -694,6 +698,7 @@ All commands support `--json` for machine-readable output.
 | `apitap replay <domain> <id> [key=val...]` | Replay an API endpoint |
 | `apitap refresh <domain>` | Refresh auth tokens via browser |
 | `apitap auth [domain]` | View or manage stored auth |
+| `apitap auth request <domain>` | Open a browser for human login, store the session |
 | `apitap mcp` | Run the full ApiTap MCP server over stdio |
 | `apitap serve <domain>` | Serve a skill file as an MCP server |
 | `apitap inspect <url>` | Discover APIs without saving |

--- a/skills/hermes/apitap/SKILL.md
+++ b/skills/hermes/apitap/SKILL.md
@@ -202,9 +202,21 @@ values either, so a non-numeric one is discarded just as quietly.
   That capture route works only for header-based auth. Capture extracts and
   stores `Authorization`, `x-api-key`, and high-entropy custom headers it sees
   after the person signs in — it does **not** persist the browser session, so a
-  site that authenticates with cookies alone will not be fixed this way. The
-  handoff that does store a session exists only as the `apitap_auth_request`
-  MCP tool, with no CLI equivalent.
+  site that authenticates with cookies alone will not be fixed this way.
+
+  The handoff that *does* store a session is available both ways — as the
+  `apitap_auth_request` MCP tool and as its CLI twin:
+
+  ```
+  apitap auth request <domain> [--login-url <url>] [--timeout <seconds>] [--json]
+  ```
+
+  Both open a **visible** browser (so they need Playwright and a display) and
+  wait for a human to sign in. The person must **close the browser window** when
+  they are done — that is the signal that login finished. On success the session
+  is stored encrypted and injected automatically on later replay and capture
+  calls. On failure the CLI exits non-zero and `--json` returns
+  `{"domain": ..., "success": false, "error": ...}`.
 
   `apitap refresh <domain>` is not a sign-in flow either: it re-mints tokens
   for a domain that already has a skill file, and fails with "No skill file

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1883,7 +1883,16 @@ async function handleAuthRequest(positional: string[], flags: Record<string, str
     });
 
     if (json) {
-      console.log(JSON.stringify({ domain, ...result }, null, 2));
+      // Serialize an explicit allow-list rather than spreading HandoffResult, so
+      // a future field on that type cannot leak cookies/tokens to stdout.
+      // Same defensive pattern as handleRefresh.
+      console.log(JSON.stringify({
+        domain,
+        success: result.success,
+        cookieCount: result.cookieCount,
+        ...(result.authDetected ? { authDetected: result.authDetected } : {}),
+        ...(result.error ? { error: result.error } : {}),
+      }, null, 2));
     } else if (result.success) {
       console.log(`  ✓ Stored auth for ${domain} (${result.cookieCount} cookies${result.authDetected ? `, ${result.authDetected}` : ''})\n`);
     } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { resolveAndValidateUrl } from './skill/ssrf.js';
 import { verifyEndpoints } from './capture/verifier.js';
 import { searchSkills } from './skill/search.js';
 import { refreshTokens } from './auth/refresh.js';
+import { requestAuth } from './auth/handoff.js';
 import { parseJwtClaims } from './capture/entropy.js';
 import { createServeServer, buildServeTools } from './serve.js';
 import { buildInspectReport, formatInspectHuman } from './inspect/report.js';
@@ -109,6 +110,8 @@ function printUsage(): void {
                                Import from topic-tagged repos (--query to filter)
     apitap refresh <domain>    Refresh auth tokens via browser
     apitap auth [domain]       View or manage stored auth
+    apitap auth request <domain>
+                               Open a browser for human login, store the session
     apitap mcp                 Run the full ApiTap MCP server over stdio
     apitap serve <domain>      Serve a skill file as an MCP server
     apitap browse <url>        Browse a URL (discover + replay in one step)
@@ -1844,7 +1847,69 @@ async function handleRefresh(positional: string[], flags: Record<string, string 
   }
 }
 
+/**
+ * `apitap auth request <domain>` — open a visible browser so a human can log in
+ * (2FA, CAPTCHAs), then store the resulting session encrypted. CLI twin of the
+ * `apitap_auth_request` MCP tool.
+ */
+async function handleAuthRequest(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const domain = positional[0];
+  const json = flags.json === true;
+
+  if (!domain) {
+    console.error('Error: Domain required. Usage: apitap auth request <domain> [--login-url <url>] [--timeout <seconds>] [--json]');
+    process.exit(1);
+  }
+
+  const loginUrl = typeof flags['login-url'] === 'string' ? flags['login-url'] : undefined;
+  const timeoutSec = typeof flags.timeout === 'string' ? parseInt(flags.timeout, 10) : undefined;
+  if (timeoutSec !== undefined && (!Number.isFinite(timeoutSec) || timeoutSec <= 0)) {
+    console.error('Error: --timeout must be a positive number of seconds');
+    process.exit(1);
+  }
+
+  const machineId = await getEffectiveMachineId();
+  const authManager = new AuthManager(APITAP_DIR, machineId);
+
+  if (!json) {
+    console.log(`\n  Opening a browser for ${domain} — log in, then CLOSE THE WINDOW when you are done.\n`);
+  }
+
+  try {
+    const result = await requestAuth(authManager, {
+      domain,
+      loginUrl,
+      timeout: timeoutSec !== undefined ? timeoutSec * 1000 : undefined,
+    });
+
+    if (json) {
+      console.log(JSON.stringify({ domain, ...result }, null, 2));
+    } else if (result.success) {
+      console.log(`  ✓ Stored auth for ${domain} (${result.cookieCount} cookies${result.authDetected ? `, ${result.authDetected}` : ''})\n`);
+    } else {
+      console.error(`  ✗ Auth request failed: ${result.error ?? 'unknown error'}\n`);
+    }
+
+    if (!result.success) process.exit(1);
+  } catch (err: any) {
+    if (json) {
+      console.log(JSON.stringify({ domain, success: false, error: err.message }, null, 2));
+    } else {
+      console.error(`  ✗ Auth request failed: ${err.message}\n`);
+    }
+    process.exit(1);
+  }
+}
+
 async function handleAuth(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  // `auth` has one subcommand. Dispatch it before treating positional[0] as a
+  // domain, otherwise `apitap auth request github.com` silently inspects a
+  // domain literally named "request" and exits 0.
+  if (positional[0] === 'request') {
+    await handleAuthRequest(positional.slice(1), flags);
+    return;
+  }
+
   const domain = positional[0];
   const json = flags.json === true;
   const machineId = await getEffectiveMachineId();
@@ -1873,6 +1938,7 @@ async function handleAuth(positional: string[], flags: Record<string, string | b
   if (!domain) {
     console.error('Error: Domain required. Usage: apitap auth <domain> [--clear] [--json]');
     console.error('       apitap auth --list [--json]');
+    console.error('       apitap auth request <domain> [--login-url <url>] [--timeout <seconds>] [--json]');
     process.exit(1);
   }
 

--- a/test/cli/auth-cli.test.ts
+++ b/test/cli/auth-cli.test.ts
@@ -10,15 +10,18 @@ import { AuthManager } from '../../src/auth/manager.js';
 
 const execFileAsync = promisify(execFile);
 
-async function runCli(args: string[], env?: Record<string, string>): Promise<{ stdout: string; stderr: string }> {
+async function runCli(args: string[], env?: Record<string, string>): Promise<{ stdout: string; stderr: string; code: number | null; killed: boolean }> {
   try {
-    return await execFileAsync(
+    const { stdout, stderr } = await execFileAsync(
       'node',
       ['--import', 'tsx', 'src/cli.ts', ...args],
       { env: { ...process.env, ...env }, timeout: 10000 },
     );
+    return { stdout, stderr, code: 0, killed: false };
   } catch (err: any) {
-    return { stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+    // err.killed is set when execFile's own timeout fired — that means the CLI
+    // hung rather than exiting, which no test here should tolerate.
+    return { stdout: err.stdout ?? '', stderr: err.stderr ?? '', code: err.code ?? null, killed: err.killed === true };
   }
 }
 
@@ -95,28 +98,47 @@ describe('CLI auth command', () => {
   // domain, print an empty-but-valid auth record and exit 0 — while `browse`
   // guidance told agents to run exactly that command.
   it('should not treat "request" as a domain name', async () => {
-    const { stdout } = await runCli(['auth', 'request', 'example.com', '--json'], {
-      APITAP_DIR: testDir,
-      APITAP_MACHINE_ID: 'test-machine-id',
-    });
+    // --timeout 1 drives the handoff to a deterministic, fast failure. Without
+    // it the default 300s timeout outlives runCli's 10s kill, leaving empty
+    // stdout — which would make every assertion below vacuously true.
+    const { stdout, stderr, code, killed } = await runCli(
+      ['auth', 'request', 'example.com', '--json', '--timeout', '1'],
+      { APITAP_DIR: testDir, APITAP_MACHINE_ID: 'test-machine-id' },
+    );
 
-    let parsed: any = null;
-    try { parsed = JSON.parse(stdout); } catch { /* non-JSON output is fine here */ }
-    assert.notEqual(parsed?.domain, 'request', 'must not report a domain literally named "request"');
+    assert.equal(killed, false, `CLI hung instead of exiting; stderr=${stderr}`);
+
+    const parsed = JSON.parse(stdout); // must be real JSON, not empty output
+    assert.equal(parsed.domain, 'example.com', 'the domain must come from positional[1], not "request"');
+    assert.equal(parsed.success, false, 'no browser session is available in tests');
+    assert.equal(code, 1, 'a failed handoff must exit non-zero');
+    assert.doesNotMatch(stdout, /"domain":\s*"request"/);
   });
 
   it('should require a domain for `auth request`', async () => {
-    const { stdout, stderr } = await runCli(['auth', 'request', '--json'], {
+    const { stdout, stderr, code, killed } = await runCli(['auth', 'request', '--json'], {
       APITAP_DIR: testDir,
       APITAP_MACHINE_ID: 'test-machine-id',
     });
 
-    assert.ok(
-      /domain required/i.test(stderr) || /usage/i.test(stderr),
-      `expected a usage error, got stderr=${stderr} stdout=${stdout}`,
-    );
+    assert.equal(killed, false, 'missing-domain path must exit immediately, not hang');
+    assert.match(stderr, /domain required/i);
+    assert.equal(code, 1);
     assert.doesNotMatch(stdout, /"domain":\s*"request"/);
   });
+
+  for (const bad of ['-1', '0', 'abc']) {
+    it(`should reject --timeout ${bad}`, async () => {
+      const { stderr, code, killed } = await runCli(
+        ['auth', 'request', 'example.com', '--json', '--timeout', bad],
+        { APITAP_DIR: testDir, APITAP_MACHINE_ID: 'test-machine-id' },
+      );
+
+      assert.equal(killed, false, 'invalid --timeout must be rejected before any browser launch');
+      assert.match(stderr, /--timeout must be a positive number of seconds/);
+      assert.equal(code, 1);
+    });
+  }
 
   it('should still treat a bare positional as the domain', async () => {
     const authManager = new AuthManager(testDir, 'test-machine-id');

--- a/test/cli/auth-cli.test.ts
+++ b/test/cli/auth-cli.test.ts
@@ -90,6 +90,46 @@ describe('CLI auth command', () => {
     const parsed = JSON.parse(stdout);
     assert.deepEqual(parsed.domains, []);
   });
+
+  // Regression: `apitap auth request <domain>` used to parse "request" as the
+  // domain, print an empty-but-valid auth record and exit 0 — while `browse`
+  // guidance told agents to run exactly that command.
+  it('should not treat "request" as a domain name', async () => {
+    const { stdout } = await runCli(['auth', 'request', 'example.com', '--json'], {
+      APITAP_DIR: testDir,
+      APITAP_MACHINE_ID: 'test-machine-id',
+    });
+
+    let parsed: any = null;
+    try { parsed = JSON.parse(stdout); } catch { /* non-JSON output is fine here */ }
+    assert.notEqual(parsed?.domain, 'request', 'must not report a domain literally named "request"');
+  });
+
+  it('should require a domain for `auth request`', async () => {
+    const { stdout, stderr } = await runCli(['auth', 'request', '--json'], {
+      APITAP_DIR: testDir,
+      APITAP_MACHINE_ID: 'test-machine-id',
+    });
+
+    assert.ok(
+      /domain required/i.test(stderr) || /usage/i.test(stderr),
+      `expected a usage error, got stderr=${stderr} stdout=${stdout}`,
+    );
+    assert.doesNotMatch(stdout, /"domain":\s*"request"/);
+  });
+
+  it('should still treat a bare positional as the domain', async () => {
+    const authManager = new AuthManager(testDir, 'test-machine-id');
+    await authManager.store('example.com', { type: 'bearer', header: 'authorization', value: 'Bearer xyz' });
+
+    const { stdout } = await runCli(['auth', 'example.com', '--json'], {
+      APITAP_DIR: testDir,
+      APITAP_MACHINE_ID: 'test-machine-id',
+    });
+
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.domain, 'example.com');
+  });
 });
 
 describe('CLI refresh command', () => {


### PR DESCRIPTION
## The bug

`apitap auth request github.com` did not do what it looks like it does. `handleAuth` read `positional[0]` straight into `domain`, so `"request"` became the domain name — it printed an empty-but-valid auth record for a domain literally called *request* and **exited 0**:

```console
$ apitap auth request example.com --json
{
  "domain": "request",
  "hasHeaderAuth": false,
  "tokens": [],
  "hasSession": false,
  "hasOAuth": false
}
$ echo $?
0
```

That is the worst shape of failure: `browse` guidance tells agents to run exactly this command, and it reports success while storing nothing. The `apitap_auth_request` **MCP** tool was implemented all along — only the CLI twin was missing.

## The fix

`handleAuth` now dispatches the subcommand before treating `positional[0]` as a domain, and a new `handleAuthRequest` wraps the same `requestAuth()` the MCP tool calls.

```mermaid
flowchart TD
    A["apitap auth request example.com"] --> B{"positional[0]"}
    B -->|before: no dispatch| C["domain = 'request'<br/>empty record, exit 0"]
    B -->|after| D{"=== 'request'?"}
    D -->|yes| E["handleAuthRequest<br/>→ requestAuth()<br/>→ browser handoff"]
    D -->|no| F["domain = positional[0]<br/>existing behaviour"]
    style C fill:#7f1d1d,color:#fff
    style E fill:#14532d,color:#fff
```

Surface matches the MCP tool: `--login-url <url>`, `--timeout <seconds>`, `--json`. Usage text and the domain-required error both mention it now.

## Verification

- 3 tests written first, 2 red before the fix (the third pins existing bare-positional behaviour so the dispatch can't regress it)
- `test/cli/auth-cli.test.ts` — 8/8
- Full suite — **1788/1788**, `npm run typecheck` clean
- Live: `auth request example.com --timeout 8 --json` → `{"success": false, "error": "No cookies captured…"}`, exit 1; no-domain → usage, exit 1

Found while running the v2.2.2 battery against the MCP server on the Hermes box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiL6kNRS8fYCiQ63KXMDYh
