### PR TITLE
fix(cli): honour the --json contract on every error-exit path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Skill file → replay/engine.ts → fetch() → JSON response
 
 ### Key Design Decisions
 
-- **CLI is the API**: agents use the same commands humans do. `--json` on every command for machine output.
+- **CLI is the API**: agents use the same commands humans do. `--json` on every command for machine output. That covers failures too — every error exit goes through `failCli()` in `src/cli.ts`, which prints `{success: false, error, usage?}` to stdout under `--json` while keeping the human line on stderr. Add new error exits via `failCli`, never a bare `console.error` + `process.exit`.
 - **Skill files are the central artifact**: JSON at `~/.apitap/skills/<domain>.json` with version, endpoints, auth config, provenance, and HMAC signature.
 - **Auth is never in skill files**: credentials live in separate encrypted storage. Skill files only contain `[stored]` placeholders.
 - **SSRF defense is multi-layered**: validated at import, at replay, after DNS resolution, and after redirects. Private IPs, cloud metadata, localhost all blocked.

--- a/README.md
+++ b/README.md
@@ -692,10 +692,14 @@ On failure, `--json` prints a parseable envelope on stdout and exits non-zero:
 }
 ```
 
+Longer guidance, where a command has any, arrives in an optional `hint` field
+rather than inside `error`, so an agent can surface the defect on its own.
+
 The human-readable line still goes to stderr, so interactive use is unchanged
 and `apitap … --json > out.json` captures only the envelope. `apitap serve` is
 the one channel exception: its stdout is the MCP stdio transport, so its failure
-envelope goes to stderr alongside its `--json` tool list.
+envelope goes to stderr alongside its `--json` tool list — and there the human
+line is suppressed, so `JSON.parse` of serve's stderr succeeds.
 
 | Command | Description |
 |---------|-------------|

--- a/README.md
+++ b/README.md
@@ -682,6 +682,21 @@ The audit log **never contains matched secret bytes**. Egress findings record pa
 
 All commands support `--json` for machine-readable output.
 
+On failure, `--json` prints a parseable envelope on stdout and exits non-zero:
+
+```json
+{
+  "success": false,
+  "error": "Domain required",
+  "usage": "apitap show <domain>"
+}
+```
+
+The human-readable line still goes to stderr, so interactive use is unchanged
+and `apitap … --json > out.json` captures only the envelope. `apitap serve` is
+the one channel exception: its stdout is the MCP stdio transport, so its failure
+envelope goes to stderr alongside its `--json` tool list.
+
 | Command | Description |
 |---------|-------------|
 | `apitap browse <url>` | Discover + replay in one step |

--- a/skills/hermes/apitap/SKILL.md
+++ b/skills/hermes/apitap/SKILL.md
@@ -293,10 +293,12 @@ values either, so a non-numeric one is discarded just as quietly.
   parseable JSON on stdout. `apitap index build` is the exception: it has no
   `--json` success mode and always prints human-readable text.
 - On failure, `--json` prints `{"success": false, "error": "...", "usage": "..."}`
-  on stdout and exits non-zero, for every command including `index build`. The
-  human-readable line still goes to stderr, so both audiences are served. The one
-  channel exception is `apitap serve`, whose stdout is the MCP transport — its
-  failure envelope goes to stderr, same as its `--json` tool list.
+  on stdout and exits non-zero, for every command including `index build`. Some
+  commands add a `hint` field with longer guidance; `error` stays short enough to
+  show on its own. The human-readable line still goes to stderr, so both
+  audiences are served. The one channel exception is `apitap serve`, whose stdout
+  is the MCP transport — its failure envelope goes to stderr instead, and there
+  the human line is dropped so the stderr stream parses as JSON.
 - `apitap list --json` shows the new skill file after an `apitap capture`,
   `apitap discover --save`, or `apitap import`.
 - `apitap stats --json` reports endpoints and token savings per domain.

--- a/skills/hermes/apitap/SKILL.md
+++ b/skills/hermes/apitap/SKILL.md
@@ -117,8 +117,9 @@ some commands write notices to stderr.
 ## Quick Reference
 
 Every command in this table accepts `--json`. The one exception anywhere in
-this file is `apitap index build` (see Pitfalls) — it takes no flags and
-always prints human-readable text.
+this file is `apitap index build` (see Pitfalls) — on success it takes no
+flags and always prints human-readable text. Its *failure* path honours
+`--json` like every other command.
 
 | Command | What it does |
 |---|---|
@@ -290,7 +291,12 @@ values either, so a non-numeric one is discarded just as quietly.
     the response payload.
 - On success, `--json` makes every table command in Quick Reference print
   parseable JSON on stdout. `apitap index build` is the exception: it has no
-  `--json` mode and always prints human-readable text.
+  `--json` success mode and always prints human-readable text.
+- On failure, `--json` prints `{"success": false, "error": "...", "usage": "..."}`
+  on stdout and exits non-zero, for every command including `index build`. The
+  human-readable line still goes to stderr, so both audiences are served. The one
+  channel exception is `apitap serve`, whose stdout is the MCP transport — its
+  failure envelope goes to stderr, same as its `--json` tool list.
 - `apitap list --json` shows the new skill file after an `apitap capture`,
   `apitap discover --save`, or `apitap import`.
 - `apitap stats --json` reports endpoints and token savings per domain.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,6 +84,62 @@ function parseArgs(argv: string[]): ParsedArgs {
   return { command, positional, flags };
 }
 
+interface FailOptions {
+  /**
+   * Usage text for the command. Emitted as its own `usage` field rather than
+   * baked into `error`, so an agent can show the error without the boilerplate.
+   */
+  usage?: string;
+  /**
+   * Also mirror `error` into a legacy `reason` field. Only for the `import`
+   * paths, which shipped `{success: false, reason}` before issue #79 unified
+   * the failure envelope. Drop once `reason` is formally deprecated.
+   */
+  legacyReason?: boolean;
+  /** Extra fields merged into the envelope (e.g. `domain`). */
+  fields?: Record<string, unknown>;
+  /**
+   * Where the JSON envelope goes. Defaults to stdout, the documented machine-
+   * output channel. `apitap serve` overrides it to stderr because there stdout
+   * is the MCP stdio transport — its `--json` tool list already goes to stderr
+   * for the same reason.
+   */
+  stream?: 'stdout' | 'stderr';
+  /**
+   * Process exit code. Defaults to 1. `apitap doctor` uses 2 for "the run
+   * itself broke", reserving 1 for "findings remain".
+   */
+  exitCode?: number;
+}
+
+/**
+ * The single error-exit path for the CLI (issue #79).
+ *
+ * `--json` is a stated design decision on every command ("CLI is the API"), but
+ * only the success half of that contract was honoured — failures printed human
+ * text to stderr and left stdout empty, so an agent parsing stdout saw nothing
+ * at all. Every error exit goes through here so the shape cannot drift per
+ * command.
+ *
+ * The human line still goes to stderr in both modes: agents parse stdout, while
+ * interactive use and `apitap … >out.json` piping keep working unchanged.
+ */
+function failCli(json: boolean, error: string, opts: FailOptions = {}): never {
+  if (json) {
+    const envelope = JSON.stringify({
+      success: false,
+      error,
+      ...(opts.legacyReason ? { reason: error } : {}),
+      ...(opts.usage ? { usage: opts.usage } : {}),
+      ...opts.fields,
+    }, null, 2);
+    if (opts.stream === 'stderr') console.error(envelope);
+    else console.log(envelope);
+  }
+  console.error(`Error: ${error}${opts.usage ? `. Usage: ${opts.usage}` : ''}`);
+  process.exit(opts.exitCode ?? 1);
+}
+
 function printUsage(): void {
   console.log(`
   apitap — API interception for AI agents
@@ -225,14 +281,14 @@ const TIER_BADGES: Record<string, string> = {
 };
 
 async function handleCapture(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  // Read `json` before the argument check: the failure path needs it too.
+  const json = flags.json === true;
   const url = positional[0];
   if (!url) {
-    console.error('Error: URL required. Usage: apitap capture <url>');
-    process.exit(1);
+    failCli(json, 'URL required', { usage: 'apitap capture <url>' });
   }
 
   const fullUrl = url.startsWith('http') ? url : `https://${url}`;
-  const json = flags.json === true;
   const duration = typeof flags.duration === 'string' ? parseInt(flags.duration, 10) : undefined;
   const port = typeof flags.port === 'string' ? parseInt(flags.port, 10) : undefined;
   const skipVerify = flags['no-verify'] === true;
@@ -242,8 +298,7 @@ async function handleCapture(positional: string[], flags: Record<string, string 
   if (flags['danger-disable-ssrf'] !== true) {
     const ssrfCheck = await resolveAndValidateUrl(fullUrl);
     if (!ssrfCheck.safe) {
-      console.error(`Error: URL blocked (SSRF): ${ssrfCheck.reason}`);
-      process.exit(1);
+      failCli(json, `URL blocked (SSRF): ${ssrfCheck.reason}`);
     }
   }
 
@@ -372,13 +427,12 @@ async function handleCapture(positional: string[], flags: Record<string, string 
 }
 
 async function handleSearch(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const json = flags.json === true;
   const query = positional.join(' ');
   if (!query) {
-    console.error('Error: Query required. Usage: apitap search <query>');
-    process.exit(1);
+    failCli(json, 'Query required', { usage: 'apitap search <query>' });
   }
 
-  const json = flags.json === true;
   const result = await searchSkills(query, SKILLS_DIR);
 
   if (json) {
@@ -424,20 +478,19 @@ async function handleList(flags: Record<string, string | boolean>): Promise<void
 }
 
 async function handleShow(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const json = flags.json === true;
   const domain = positional[0];
   if (!domain) {
-    console.error('Error: Domain required. Usage: apitap show <domain>');
-    process.exit(1);
+    failCli(json, 'Domain required', { usage: 'apitap show <domain>' });
   }
 
   // Intentionally skip HMAC for browse-only — verification happens at replay time
   const skill = await readSkillFile(domain, SKILLS_DIR, { verifySignature: false });
   if (!skill) {
-    console.error(`Error: No skill file found for "${domain}". Run \`apitap capture\` first.`);
-    process.exit(1);
+    failCli(json, `No skill file found for "${domain}". Run \`apitap capture\` first.`, {
+      fields: { domain },
+    });
   }
-
-  const json = flags.json === true;
 
   if (json) {
     console.log(JSON.stringify(skill, null, 2));
@@ -462,25 +515,25 @@ async function handleShow(positional: string[], flags: Record<string, string | b
 }
 
 async function handleReplay(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
-  const [domain, endpointId, ...paramArgs] = positional;
-  if (!domain || !endpointId) {
-    console.error('Error: Domain and endpoint required. Usage: apitap replay <domain> <endpoint-id> [key=value...]');
-    process.exit(1);
-  }
-
-  // Parsed up front (ordering trap): the auth warning below fires before the
-  // rest of the flags are read, so `json` and the `notices` sink must exist
-  // by then to keep --json stderr clean.
+  // Parsed up front (ordering trap): the argument check and the auth warning
+  // below both fire before the rest of the flags are read, so `json` and the
+  // `notices` sink must exist by then to keep --json output well-formed.
   const json = flags.json === true;
   const notices: string[] = [];
+
+  const [domain, endpointId, ...paramArgs] = positional;
+  if (!domain || !endpointId) {
+    failCli(json, 'Domain and endpoint required', {
+      usage: 'apitap replay <domain> <endpoint-id> [key=value...]',
+    });
+  }
 
   const machineId = await getMachineId();
   const signingKey = deriveSigningKey(machineId);
   const trustUnsigned = flags['trust-unsigned'] === true;
   const skill = await readSkillFile(domain, SKILLS_DIR, { verifySignature: true, signingKey, trustUnsigned });
   if (!skill) {
-    console.error(`Error: No skill file found for "${domain}".`);
-    process.exit(1);
+    failCli(json, `No skill file found for "${domain}".`, { fields: { domain } });
   }
 
   // Parse key=value params
@@ -638,13 +691,15 @@ async function handleImport(positional: string[], flags: Record<string, string |
     return;
   }
 
+  const json = flags.json === true;
+
   const source = positional[0];
   if (!source) {
-    console.error('Error: File path or URL required. Usage: apitap import <file|url>');
-    process.exit(1);
+    failCli(json, 'File path or URL required', {
+      usage: 'apitap import <file|url>',
+      legacyReason: true,
+    });
   }
-
-  const json = flags.json === true;
 
   // Load content — from URL or file
   let rawText: string;
@@ -664,12 +719,7 @@ async function handleImport(positional: string[], flags: Record<string, string |
       rawText = await response.text();
     } catch (err: any) {
       const msg = `Failed to fetch ${source}: ${err.message}`;
-      if (json) {
-        console.log(JSON.stringify({ success: false, reason: msg }));
-      } else {
-        console.error(`Error: ${msg}`);
-      }
-      process.exit(1);
+      failCli(json, msg, { legacyReason: true });
     }
   } else {
     try {
@@ -678,12 +728,7 @@ async function handleImport(positional: string[], flags: Record<string, string |
       sourceUrl = `file://${resolve(source)}`;
     } catch (err: any) {
       const msg = `Failed to read ${source}: ${err.message}`;
-      if (json) {
-        console.log(JSON.stringify({ success: false, reason: msg }));
-      } else {
-        console.error(`Error: ${msg}`);
-      }
-      process.exit(1);
+      failCli(json, msg, { legacyReason: true });
     }
   }
 
@@ -699,12 +744,7 @@ async function handleImport(positional: string[], flags: Record<string, string |
         throw new Error('YAML parsed to non-object');
       }
     } catch (yamlErr: any) {
-      if (json) {
-        console.log(JSON.stringify({ success: false, reason: `Invalid JSON/YAML: ${yamlErr.message}` }));
-      } else {
-        console.error(`Error: Could not parse as JSON or YAML: ${yamlErr.message}`);
-      }
-      process.exit(1);
+      failCli(json, `Could not parse as JSON or YAML: ${yamlErr.message}`, { legacyReason: true });
     }
   }
 
@@ -749,24 +789,14 @@ async function handleSkillFileImport(filePath: string, json: boolean): Promise<v
     const dnsCheck = await resolveAndValidateUrl(raw.baseUrl);
     if (!dnsCheck.safe) {
       const msg = `DNS rebinding risk: ${dnsCheck.reason}`;
-      if (json) {
-        console.log(JSON.stringify({ success: false, reason: msg }));
-      } else {
-        console.error(`Error: ${msg}`);
-      }
-      process.exit(1);
+      failCli(json, msg, { legacyReason: true });
     }
   }
 
   const result = await importSkillFile(filePath, undefined, key);
 
   if (!result.success) {
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: result.reason }));
-    } else {
-      console.error(`Error: ${result.reason}`);
-    }
-    process.exit(1);
+    failCli(json, result.reason ?? 'Import failed', { legacyReason: true });
   }
 
   if (json) {
@@ -793,12 +823,7 @@ async function handleOpenAPIImport(
     importResult = convertOpenAPISpec(spec, specUrl);
   } catch (err: any) {
     const msg = `Failed to convert OpenAPI spec: ${err.message}`;
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(`Error: ${msg}`);
-    }
-    process.exit(1);
+    failCli(json, msg, { legacyReason: true });
   }
 
   const { domain, endpoints, meta } = importResult;
@@ -812,12 +837,7 @@ async function handleOpenAPIImport(
   const dnsCheck = await resolveAndValidateUrl(`https://${domain}`);
   if (!dnsCheck.safe) {
     const msg = `DNS rebinding risk for ${domain}: ${dnsCheck.reason}`;
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(`Error: ${msg}`);
-    }
-    process.exit(1);
+    failCli(json, msg, { legacyReason: true });
   }
 
   // Read existing skill file (if any)
@@ -921,12 +941,7 @@ async function handleApisGuruImport(flags: Record<string, string | boolean>): Pr
     entries = filterEntries(allEntries, { search, limit, preferOpenapi3: true });
   } catch (err: any) {
     const msg = `Failed to fetch APIs.guru list: ${err.message}`;
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(`Error: ${msg}`);
-    }
-    process.exit(1);
+    failCli(json, msg, { legacyReason: true });
   }
 
   if (entries.length === 0) {
@@ -1092,13 +1107,10 @@ async function handleSwaggerHubImport(flags: Record<string, string | boolean>): 
   const skillsDir = SKILLS_DIR || join(APITAP_DIR, 'skills');
 
   if (!query) {
-    const msg = 'Error: --query required for SwaggerHub import. Usage: apitap import --from swaggerhub --query <term>';
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(msg);
-    }
-    process.exit(1);
+    failCli(json, '--query required for SwaggerHub import', {
+      usage: 'apitap import --from swaggerhub --query <term>',
+      legacyReason: true,
+    });
   }
 
   if (!json) {
@@ -1114,12 +1126,7 @@ async function handleSwaggerHubImport(flags: Record<string, string | boolean>): 
     totalCount = result.totalCount;
   } catch (err: any) {
     const msg = `Failed to search SwaggerHub: ${err.message}`;
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(`Error: ${msg}`);
-    }
-    process.exit(1);
+    failCli(json, msg, { legacyReason: true });
   }
 
   if (!json) {
@@ -1256,21 +1263,13 @@ async function handleGitHubImport(flags: Record<string, string | boolean>): Prom
   // Mutual exclusion
   if (org && topicFlag) {
     const msg = '--org and --topic are mutually exclusive';
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(`Error: ${msg}`);
-    }
-    process.exit(1);
+    failCli(json, msg, { legacyReason: true });
   }
   if (!org && !topicFlag) {
-    const msg = '--org or --topic required. Usage: apitap import --from github --org <name> OR --topic [name]';
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(`Error: ${msg}`);
-    }
-    process.exit(1);
+    failCli(json, '--org or --topic required', {
+      usage: 'apitap import --from github --org <name> OR --topic [name]',
+      legacyReason: true,
+    });
   }
 
   // --min-stars: different defaults per mode
@@ -1287,12 +1286,7 @@ async function handleGitHubImport(flags: Record<string, string | boolean>): Prom
   const token = await resolveGitHubToken();
   if (org && token === null) {
     const msg = "--org requires a GitHub token. Run 'gh auth login' or set GITHUB_TOKEN.";
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(`Error: ${msg}`);
-    }
-    process.exit(1);
+    failCli(json, msg, { legacyReason: true });
   }
 
   // Discovery phase
@@ -1320,12 +1314,7 @@ async function handleGitHubImport(flags: Record<string, string | boolean>): Prom
     }
   } catch (err: any) {
     const msg = `GitHub discovery failed: ${err.message}`;
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(`Error: ${msg}`);
-    }
-    process.exit(1);
+    failCli(json, msg, { legacyReason: true });
   }
 
   // Filter: forks, archived, stale, min-stars
@@ -1599,12 +1588,7 @@ async function handleKnownSpecsImport(flags: Record<string, string | boolean>): 
     allSpecs = loadKnownSpecs();
   } catch (err: any) {
     const msg = `Failed to load known-specs.json: ${err.message}`;
-    if (json) {
-      console.log(JSON.stringify({ success: false, reason: msg }));
-    } else {
-      console.error(`Error: ${msg}`);
-    }
-    process.exit(1);
+    failCli(json, msg, { legacyReason: true });
   }
 
   // Filter by --query
@@ -1797,22 +1781,20 @@ async function handleKnownSpecsImport(flags: Record<string, string | boolean>): 
 }
 
 async function handleRefresh(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const json = flags.json === true;
   const domain = positional[0];
   if (!domain) {
-    console.error('Error: Domain required. Usage: apitap refresh <domain>');
-    process.exit(1);
+    failCli(json, 'Domain required', { usage: 'apitap refresh <domain>' });
   }
 
   const trustUnsigned = flags['trust-unsigned'] === true;
   const skill = await readSkillFile(domain, SKILLS_DIR, { trustUnsigned });
   if (!skill) {
-    console.error(`Error: No skill file found for "${domain}".`);
-    process.exit(1);
+    failCli(json, `No skill file found for "${domain}".`, { fields: { domain } });
   }
 
   const machineId = await getEffectiveMachineId();
   const authManager = new AuthManager(APITAP_DIR, machineId);
-  const json = flags.json === true;
 
   if (!json) {
     console.log(`\n  🔄 Refreshing tokens for ${domain}...`);
@@ -1830,6 +1812,13 @@ async function handleRefresh(positional: string[], flags: Record<string, string 
       tokens: Object.fromEntries(Object.keys(result.tokens).map(k => [k, '[redacted]'])),
     };
     console.log(JSON.stringify(safeResult, null, 2));
+    // Exit code must agree with the envelope. Previously a failed refresh under
+    // --json printed success:false but exited 0, so callers keying on the exit
+    // code saw a success (issue #79, same failure-contract family).
+    if (!result.success) {
+      console.error(`Error: Refresh failed: ${result.error || 'no tokens captured'}`);
+      process.exit(1);
+    }
   } else if (result.success) {
     if (result.oauthRefreshed) {
       console.log(`  ✓ OAuth token refreshed via token endpoint`);
@@ -1857,15 +1846,15 @@ async function handleAuthRequest(positional: string[], flags: Record<string, str
   const json = flags.json === true;
 
   if (!domain) {
-    console.error('Error: Domain required. Usage: apitap auth request <domain> [--login-url <url>] [--timeout <seconds>] [--json]');
-    process.exit(1);
+    failCli(json, 'Domain required', {
+      usage: 'apitap auth request <domain> [--login-url <url>] [--timeout <seconds>] [--json]',
+    });
   }
 
   const loginUrl = typeof flags['login-url'] === 'string' ? flags['login-url'] : undefined;
   const timeoutSec = typeof flags.timeout === 'string' ? parseInt(flags.timeout, 10) : undefined;
   if (timeoutSec !== undefined && (!Number.isFinite(timeoutSec) || timeoutSec <= 0)) {
-    console.error('Error: --timeout must be a positive number of seconds');
-    process.exit(1);
+    failCli(json, '--timeout must be a positive number of seconds', { fields: { domain } });
   }
 
   const machineId = await getEffectiveMachineId();
@@ -1895,17 +1884,20 @@ async function handleAuthRequest(positional: string[], flags: Record<string, str
       }, null, 2));
     } else if (result.success) {
       console.log(`  ✓ Stored auth for ${domain} (${result.cookieCount} cookies${result.authDetected ? `, ${result.authDetected}` : ''})\n`);
-    } else {
-      console.error(`  ✗ Auth request failed: ${result.error ?? 'unknown error'}\n`);
     }
 
-    if (!result.success) process.exit(1);
+    // The human line goes to stderr in both modes (issue #79). This path keeps
+    // its bespoke stdout envelope rather than calling failCli, so the allow-list
+    // above stays the single place that decides what may reach stdout.
+    if (!result.success) {
+      console.error(`  ✗ Auth request failed: ${result.error ?? 'unknown error'}\n`);
+      process.exit(1);
+    }
   } catch (err: any) {
     if (json) {
       console.log(JSON.stringify({ domain, success: false, error: err.message }, null, 2));
-    } else {
-      console.error(`  ✗ Auth request failed: ${err.message}\n`);
     }
+    console.error(`  ✗ Auth request failed: ${err.message}\n`);
     process.exit(1);
   }
 }
@@ -1945,10 +1937,9 @@ async function handleAuth(positional: string[], flags: Record<string, string | b
 
   // Require domain for other operations
   if (!domain) {
-    console.error('Error: Domain required. Usage: apitap auth <domain> [--clear] [--json]');
-    console.error('       apitap auth --list [--json]');
-    console.error('       apitap auth request <domain> [--login-url <url>] [--timeout <seconds>] [--json]');
-    process.exit(1);
+    failCli(json, 'Domain required', {
+      usage: 'apitap auth <domain> [--clear] [--json] | apitap auth --list [--json] | apitap auth request <domain> [--login-url <url>] [--timeout <seconds>] [--json]',
+    });
   }
 
   // Clear auth for domain
@@ -2027,14 +2018,13 @@ async function handleAuth(positional: string[], flags: Record<string, string | b
 }
 
 async function handleServe(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
-  const domain = positional[0];
-  if (!domain) {
-    console.error('Error: Domain required. Usage: apitap serve <domain>');
-    process.exit(1);
-  }
-
   const noAuth = flags['no-auth'] === true;
   const json = flags.json === true;
+
+  const domain = positional[0];
+  if (!domain) {
+    failCli(json, 'Domain required', { usage: 'apitap serve <domain>', stream: 'stderr' });
+  }
 
   try {
     const server = await createServeServer(domain, {
@@ -2060,8 +2050,7 @@ async function handleServe(positional: string[], flags: Record<string, string | 
     const transport = new StdioServerTransport();
     await server.connect(transport);
   } catch (err: any) {
-    console.error(`Error: ${err.message}`);
-    process.exit(1);
+    failCli(json, err.message, { stream: 'stderr' });
   }
 }
 
@@ -2091,10 +2080,10 @@ function timeAgo(isoDate: string): string {
 }
 
 async function handleInspect(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const json = flags.json === true;
   const url = positional[0];
   if (!url) {
-    console.error('Usage: apitap inspect <url>');
-    process.exit(1);
+    failCli(json, 'URL required', { usage: 'apitap inspect <url>' });
   }
 
   // SSRF validation for CLI (H6 fix)
@@ -2102,12 +2091,10 @@ async function handleInspect(positional: string[], flags: Record<string, string 
   if (flags['danger-disable-ssrf'] !== true) {
     const ssrfCheck = await resolveAndValidateUrl(fullInspectUrl);
     if (!ssrfCheck.safe) {
-      console.error(`Error: URL blocked (SSRF): ${ssrfCheck.reason}`);
-      process.exit(1);
+      failCli(json, `URL blocked (SSRF): ${ssrfCheck.reason}`);
     }
   }
 
-  const json = flags.json === true;
   const duration = typeof flags.duration === 'string' ? parseInt(flags.duration, 10) : 30;
 
   if (!json) {
@@ -2187,26 +2174,20 @@ async function handleStats(flags: Record<string, string | boolean>): Promise<voi
 }
 
 async function handleDiscover(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
-  const url = positional[0];
-  if (!url) {
-    console.error('Error: URL required. Usage: apitap discover <url>');
-    process.exit(1);
-  }
-
   const json = flags.json === true;
   const save = flags.save === true;
+
+  const url = positional[0];
+  if (!url) {
+    failCli(json, 'URL required', { usage: 'apitap discover <url>' });
+  }
 
   // SSRF validation for CLI (H6 fix)
   const fullDiscoverUrl = url.startsWith('http') ? url : `https://${url}`;
   if (flags['danger-disable-ssrf'] !== true) {
     const ssrfCheck = await resolveAndValidateUrl(fullDiscoverUrl);
     if (!ssrfCheck.safe) {
-      if (json) {
-        console.log(JSON.stringify({ error: `URL blocked (SSRF): ${ssrfCheck.reason}` }));
-      } else {
-        console.error(`Error: URL blocked (SSRF): ${ssrfCheck.reason}`);
-      }
-      process.exit(1);
+      failCli(json, `URL blocked (SSRF): ${ssrfCheck.reason}`);
     }
   }
 
@@ -2318,14 +2299,14 @@ async function handleDiscover(positional: string[], flags: Record<string, string
 }
 
 async function handleBrowse(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
-  const url = positional[0];
-  if (!url) {
-    console.error('Error: URL required. Usage: apitap browse <url>');
-    process.exit(1);
-  }
-
   const json = flags.json === true;
   const notices: string[] = [];
+
+  const url = positional[0];
+  if (!url) {
+    failCli(json, 'URL required', { usage: 'apitap browse <url>' });
+  }
+
   const fullUrl = url.startsWith('http') ? url : `https://${url}`;
 
   if (!json) {
@@ -2395,21 +2376,20 @@ async function handleBrowse(positional: string[], flags: Record<string, string |
 }
 
 async function handlePeek(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const json = flags.json === true;
+
   const url = positional[0];
   if (!url) {
-    console.error('Error: URL required. Usage: apitap peek <url>');
-    process.exit(1);
+    failCli(json, 'URL required', { usage: 'apitap peek <url>' });
   }
 
-  const json = flags.json === true;
   const fullUrl = url.startsWith('http') ? url : `https://${url}`;
 
   // SSRF validation for CLI (H6 fix)
   if (flags['danger-disable-ssrf'] !== true) {
     const ssrfCheck = await resolveAndValidateUrl(fullUrl);
     if (!ssrfCheck.safe) {
-      console.error(`Error: URL blocked (SSRF): ${ssrfCheck.reason}`);
-      process.exit(1);
+      failCli(json, `URL blocked (SSRF): ${ssrfCheck.reason}`);
     }
   }
 
@@ -2434,13 +2414,13 @@ async function handlePeek(positional: string[], flags: Record<string, string | b
 }
 
 async function handleRead(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const json = flags.json === true;
+
   const url = positional[0];
   if (!url) {
-    console.error('Error: URL required. Usage: apitap read <url>');
-    process.exit(1);
+    failCli(json, 'URL required', { usage: 'apitap read <url>' });
   }
 
-  const json = flags.json === true;
   const fullUrl = url.startsWith('http') ? url : `https://${url}`;
   const maxBytes = typeof flags['max-bytes'] === 'string' ? parseInt(flags['max-bytes'], 10) : undefined;
 
@@ -2448,8 +2428,7 @@ async function handleRead(positional: string[], flags: Record<string, string | b
   if (flags['danger-disable-ssrf'] !== true) {
     const ssrfCheck = await resolveAndValidateUrl(fullUrl);
     if (!ssrfCheck.safe) {
-      console.error(`Error: URL blocked (SSRF): ${ssrfCheck.reason}`);
-      process.exit(1);
+      failCli(json, `URL blocked (SSRF): ${ssrfCheck.reason}`);
     }
   }
 
@@ -2463,12 +2442,7 @@ async function handleRead(positional: string[], flags: Record<string, string | b
   const result = await read(fullUrl, { maxBytes, scan: scanFlag, includeImages });
 
   if (!result) {
-    if (json) {
-      console.log(JSON.stringify({ error: 'Failed to read content' }));
-    } else {
-      console.error('  Failed to read content\n');
-    }
-    process.exit(1);
+    failCli(json, 'Failed to read content', { fields: { url: fullUrl } });
   }
 
   if (json) {
@@ -2599,16 +2573,15 @@ async function handleAudit(flags: Record<string, string | boolean>): Promise<voi
   console.log();
 }
 
-async function handleForget(positional: string[]): Promise<void> {
+async function handleForget(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const json = flags.json === true;
   const domain = positional[0];
   if (!domain) {
-    console.error('Error: Domain required. Usage: apitap forget <domain>');
-    process.exit(1);
+    failCli(json, 'Domain required', { usage: 'apitap forget <domain>' });
   }
 
   if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(domain) || domain.includes('..')) {
-    console.error('Error: Invalid domain name');
-    process.exit(1);
+    failCli(json, 'Invalid domain name', { fields: { domain } });
   }
 
   const skillsDir = SKILLS_DIR || join(APITAP_DIR, 'skills');
@@ -2669,8 +2642,8 @@ async function handleDoctor(positional: string[], flags: Record<string, string |
     const signingKey = deriveSigningKey(machineId);
     const staleDays = typeof flags['stale-days'] === 'string' ? Number(flags['stale-days']) : undefined;
     if (staleDays !== undefined && (!Number.isFinite(staleDays) || staleDays < 0)) {
-      console.error('Error: --stale-days must be a non-negative number');
-      process.exit(2);
+      failCli(flags.json === true || typeof flags.json === 'string',
+        '--stale-days must be a non-negative number', { exitCode: 2 });
     }
     // The house arg parser greedily assigns the next bare token as a flag's
     // value, so `--fix polymarket.com` produces flags.fix === 'polymarket.com'
@@ -2717,18 +2690,18 @@ async function handleDoctor(positional: string[], flags: Record<string, string |
     }
     process.exit(report.remaining.length > 0 ? 1 : 0);
   } catch (err: any) {
-    console.error(`Error: ${err.message}`);
-    process.exit(2);
+    failCli(flags.json === true || typeof flags.json === 'string', err.message, { exitCode: 2 });
   }
 }
 
-async function handleIndex(positional: string[]): Promise<void> {
+async function handleIndex(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const json = flags.json === true;
   const subcommand = positional[0];
   if (subcommand !== 'build') {
-    console.error('Usage: apitap index build');
-    console.error('  Force rebuild the search index from all skill files on disk.');
-    console.error('  Run this after manually editing skill files outside of apitap commands.');
-    process.exit(1);
+    failCli(json, 'Unknown index subcommand — force rebuild the search index from all skill files on disk, after manually editing them outside of apitap commands', {
+      usage: 'apitap index build',
+      fields: { subcommand: subcommand ?? null },
+    });
   }
 
   const skillsDir = SKILLS_DIR || join(APITAP_DIR, 'skills');
@@ -2739,15 +2712,15 @@ async function handleIndex(positional: string[]): Promise<void> {
 }
 
 async function handleExtension(positional: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const json = flags.json === true;
   const subcommand = positional[0];
 
   if (subcommand === 'install') {
     const extensionId = flags['extension-id'];
     if (!extensionId || typeof extensionId !== 'string') {
-      console.error('Usage: apitap extension install --extension-id <id>');
-      console.error('');
-      console.error('Find your extension ID at chrome://extensions (enable Developer mode)');
-      process.exit(1);
+      failCli(json, 'Extension ID required — find yours at chrome://extensions (enable Developer mode)', {
+        usage: 'apitap extension install --extension-id <id>',
+      });
     }
 
     // Resolve the native host script path (always use dist/ — compiled output)
@@ -2769,15 +2742,15 @@ async function handleExtension(positional: string[], flags: Record<string, strin
       }
     }
     if (installed.length === 0) {
-      console.error('No browsers found. Are you on Linux or macOS?');
-      process.exit(1);
+      failCli(json, 'No browsers found. Are you on Linux or macOS?', { fields: { errors } });
     }
     return;
   }
 
-  console.error(`Unknown extension subcommand: ${subcommand}`);
-  console.error('Usage: apitap extension install --extension-id <id>');
-  process.exit(1);
+  failCli(json, `Unknown extension subcommand: ${subcommand}`, {
+    usage: 'apitap extension install --extension-id <id>',
+    fields: { subcommand: subcommand ?? null },
+  });
 }
 
 async function handleAttach(_positional: string[], flags: Record<string, string | boolean>): Promise<void> {
@@ -2859,7 +2832,7 @@ async function main(): Promise<void> {
       await handleAudit(flags);
       break;
     case 'forget':
-      await handleForget(positional);
+      await handleForget(positional, flags);
       break;
     case 'extension':
       await handleExtension(positional, flags);
@@ -2868,7 +2841,7 @@ async function main(): Promise<void> {
       await handleAttach(positional, flags);
       break;
     case 'index':
-      await handleIndex(positional);
+      await handleIndex(positional, flags);
       break;
     default:
       printUsage();
@@ -2876,6 +2849,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error(`Error: ${err.message}`);
-  process.exit(1);
+  // Last resort: an unexpected throw is still a failure an agent must be able
+  // to parse, so re-read --json off argv rather than leaving stdout empty.
+  failCli(parseArgs(process.argv.slice(2)).flags.json === true, err.message);
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,12 @@ interface FailOptions {
    * the failure envelope. Drop once `reason` is formally deprecated.
    */
   legacyReason?: boolean;
+  /**
+   * Extra guidance shown to both audiences: its own `hint` field in the
+   * envelope, and appended to the human stderr line. Keeps help prose out of
+   * `error`, which agents surface on its own.
+   */
+  hint?: string;
   /** Extra fields merged into the envelope (e.g. `domain`). */
   fields?: Record<string, unknown>;
   /**
@@ -127,16 +133,26 @@ interface FailOptions {
 function failCli(json: boolean, error: string, opts: FailOptions = {}): never {
   if (json) {
     const envelope = JSON.stringify({
+      // Caller fields spread first so the contract keys below always win — a
+      // stray `fields: { error }` must not be able to redefine the envelope.
+      ...opts.fields,
       success: false,
       error,
       ...(opts.legacyReason ? { reason: error } : {}),
       ...(opts.usage ? { usage: opts.usage } : {}),
-      ...opts.fields,
+      ...(opts.hint ? { hint: opts.hint } : {}),
     }, null, 2);
-    if (opts.stream === 'stderr') console.error(envelope);
-    else console.log(envelope);
+    if (opts.stream === 'stderr') {
+      console.error(envelope);
+      // stderr is the only channel this command has, so adding the human line
+      // would leave it unparseable for the agent it was just written for.
+      process.exit(opts.exitCode ?? 1);
+    }
+    console.log(envelope);
   }
-  console.error(`Error: ${error}${opts.usage ? `. Usage: ${opts.usage}` : ''}`);
+  console.error(
+    `Error: ${error}${opts.usage ? `. Usage: ${opts.usage}` : ''}${opts.hint ? `\n  ${opts.hint}` : ''}`,
+  );
   process.exit(opts.exitCode ?? 1);
 }
 
@@ -2698,8 +2714,9 @@ async function handleIndex(positional: string[], flags: Record<string, string | 
   const json = flags.json === true;
   const subcommand = positional[0];
   if (subcommand !== 'build') {
-    failCli(json, 'Unknown index subcommand — force rebuild the search index from all skill files on disk, after manually editing them outside of apitap commands', {
+    failCli(json, 'Unknown index subcommand', {
       usage: 'apitap index build',
+      hint: 'Force rebuild the search index from all skill files on disk. Run this after manually editing skill files outside of apitap commands.',
       fields: { subcommand: subcommand ?? null },
     });
   }
@@ -2718,8 +2735,9 @@ async function handleExtension(positional: string[], flags: Record<string, strin
   if (subcommand === 'install') {
     const extensionId = flags['extension-id'];
     if (!extensionId || typeof extensionId !== 'string') {
-      failCli(json, 'Extension ID required — find yours at chrome://extensions (enable Developer mode)', {
+      failCli(json, 'Extension ID required', {
         usage: 'apitap extension install --extension-id <id>',
+        hint: 'Find your extension ID at chrome://extensions (enable Developer mode).',
       });
     }
 

--- a/test/cli/json-error-contract.test.ts
+++ b/test/cli/json-error-contract.test.ts
@@ -1,0 +1,173 @@
+// test/cli/json-error-contract.test.ts
+//
+// Issue #79: with `--json`, error-exit paths must honour the machine-output
+// contract — a parseable envelope on stdout, not just human text on stderr.
+//
+// The contract:
+//   - stdout parses as JSON: { success: false, error: string, usage?: string }
+//   - stderr still carries the human line (interactive UX is preserved)
+//   - exit code is non-zero
+//
+// These assert the *shape* per command, not just a non-zero exit, so the
+// failure contract cannot regress silently the way `auth request` did.
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+async function runCli(args: string[], env?: Record<string, string>): Promise<CliResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      'node',
+      ['--import', 'tsx', 'src/cli.ts', ...args],
+      { env: { ...process.env, ...env }, timeout: 20000 },
+    );
+    return { stdout, stderr, code: 0 };
+  } catch (err: any) {
+    return { stdout: err.stdout ?? '', stderr: err.stderr ?? '', code: err.code ?? 1 };
+  }
+}
+
+/**
+ * Assert the full JSON failure contract on a CLI result. Returns the parsed
+ * envelope so callers can make command-specific assertions on top.
+ */
+function assertJsonFailure(result: CliResult, label: string): Record<string, unknown> {
+  assert.notEqual(result.code, 0, `${label}: expected non-zero exit`);
+  assert.notEqual(result.stdout.trim(), '', `${label}: stdout must not be empty under --json`);
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    assert.fail(`${label}: stdout is not valid JSON:\n${result.stdout}`);
+  }
+
+  assert.equal(parsed.success, false, `${label}: envelope must carry success:false`);
+  assert.equal(typeof parsed.error, 'string', `${label}: envelope must carry a string error`);
+  assert.notEqual(parsed.error, '', `${label}: error must not be empty`);
+  assert.notEqual(result.stderr.trim(), '', `${label}: human line must still reach stderr`);
+
+  return parsed;
+}
+
+describe('CLI --json failure contract (issue #79)', () => {
+  let testDir: string;
+  let env: Record<string, string>;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'apitap-json-err-'));
+    env = { APITAP_DIR: testDir, APITAP_SKILLS_DIR: join(testDir, 'skills') };
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('missing required arguments', () => {
+    const cases: Array<{ name: string; args: string[]; usageContains: string }> = [
+      { name: 'show', args: ['show'], usageContains: 'apitap show' },
+      { name: 'search', args: ['search'], usageContains: 'apitap search' },
+      { name: 'replay', args: ['replay'], usageContains: 'apitap replay' },
+      { name: 'refresh', args: ['refresh'], usageContains: 'apitap refresh' },
+      { name: 'import', args: ['import'], usageContains: 'apitap import' },
+      { name: 'capture', args: ['capture'], usageContains: 'apitap capture' },
+      { name: 'discover', args: ['discover'], usageContains: 'apitap discover' },
+      { name: 'inspect', args: ['inspect'], usageContains: 'apitap inspect' },
+      { name: 'browse', args: ['browse'], usageContains: 'apitap browse' },
+      { name: 'peek', args: ['peek'], usageContains: 'apitap peek' },
+      { name: 'read', args: ['read'], usageContains: 'apitap read' },
+      { name: 'forget', args: ['forget'], usageContains: 'apitap forget' },
+      { name: 'auth request', args: ['auth', 'request'], usageContains: 'apitap auth request' },
+      { name: 'auth', args: ['auth'], usageContains: 'apitap auth' },
+    ];
+
+    for (const c of cases) {
+      it(`${c.name} emits a JSON envelope on stdout`, async () => {
+        const result = await runCli([...c.args, '--json'], env);
+        const parsed = assertJsonFailure(result, c.name);
+        assert.equal(
+          typeof parsed.usage,
+          'string',
+          `${c.name}: usage text belongs in its own field, not baked into error`,
+        );
+        assert.ok(
+          (parsed.usage as string).includes(c.usageContains),
+          `${c.name}: usage should mention "${c.usageContains}", got "${parsed.usage}"`,
+        );
+        assert.ok(
+          !(parsed.error as string).includes('Usage:'),
+          `${c.name}: error must not bake in the usage string`,
+        );
+      });
+    }
+  });
+
+  describe('serve — envelope on stderr, not stdout', () => {
+    // `apitap serve` reserves stdout for the MCP stdio transport; its `--json`
+    // tool list already goes to stderr. The failure envelope follows that
+    // channel rather than the repo-wide stdout default.
+    it('serve emits the JSON envelope on stderr', async () => {
+      const result = await runCli(['serve', '--json'], env);
+      assert.notEqual(result.code, 0);
+      assert.equal(result.stdout.trim(), '', 'serve must keep stdout free for the MCP transport');
+
+      const jsonLine = result.stderr.slice(result.stderr.indexOf('{'), result.stderr.lastIndexOf('}') + 1);
+      const parsed = JSON.parse(jsonLine);
+      assert.equal(parsed.success, false);
+      assert.equal(typeof parsed.error, 'string');
+      assert.ok((parsed.usage as string).includes('apitap serve'));
+    });
+  });
+
+  describe('missing skill file', () => {
+    for (const cmd of ['show', 'refresh']) {
+      it(`${cmd} on an unknown domain emits a JSON envelope`, async () => {
+        const result = await runCli([cmd, 'nonexistent-domain.invalid', '--json'], env);
+        const parsed = assertJsonFailure(result, `${cmd} unknown domain`);
+        assert.ok(
+          (parsed.error as string).toLowerCase().includes('no skill file'),
+          `${cmd}: error should name the missing skill file, got "${parsed.error}"`,
+        );
+      });
+    }
+
+    it('replay on an unknown domain emits a JSON envelope', async () => {
+      const result = await runCli(['replay', 'nonexistent-domain.invalid', 'some-endpoint', '--json'], env);
+      assertJsonFailure(result, 'replay unknown domain');
+    });
+  });
+
+  describe('legacy `reason` alias', () => {
+    it('import failures still carry reason alongside error', async () => {
+      const result = await runCli(['import', '/nonexistent/path/to/skill.json', '--json'], env);
+      const parsed = assertJsonFailure(result, 'import missing file');
+      assert.equal(
+        parsed.reason,
+        parsed.error,
+        'import kept a `reason` field historically; it must mirror `error` until deprecated',
+      );
+    });
+  });
+
+  describe('human mode is unchanged', () => {
+    it('without --json, the error goes to stderr and stdout stays empty', async () => {
+      const result = await runCli(['show'], env);
+      assert.notEqual(result.code, 0);
+      assert.equal(result.stdout.trim(), '', 'human mode must not emit JSON on stdout');
+      assert.match(result.stderr, /Error: /);
+      assert.match(result.stderr, /Usage: apitap show/);
+    });
+  });
+});

--- a/test/cli/json-error-contract.test.ts
+++ b/test/cli/json-error-contract.test.ts
@@ -17,6 +17,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { writeSkillFile } from '../../src/skill/store.js';
+import type { SkillFile } from '../../src/types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -118,16 +120,24 @@ describe('CLI --json failure contract (issue #79)', () => {
     // `apitap serve` reserves stdout for the MCP stdio transport; its `--json`
     // tool list already goes to stderr. The failure envelope follows that
     // channel rather than the repo-wide stdout default.
-    it('serve emits the JSON envelope on stderr', async () => {
+    it('serve emits the JSON envelope on stderr, and nothing else', async () => {
       const result = await runCli(['serve', '--json'], env);
       assert.notEqual(result.code, 0);
       assert.equal(result.stdout.trim(), '', 'serve must keep stdout free for the MCP transport');
 
-      const jsonLine = result.stderr.slice(result.stderr.indexOf('{'), result.stderr.lastIndexOf('}') + 1);
-      const parsed = JSON.parse(jsonLine);
+      // stderr is serve's only channel under --json, so it must parse whole —
+      // no human line appended for an audience that has nowhere else to read.
+      const parsed = JSON.parse(result.stderr);
       assert.equal(parsed.success, false);
       assert.equal(typeof parsed.error, 'string');
       assert.ok((parsed.usage as string).includes('apitap serve'));
+    });
+
+    it('serve without --json still prints the human line', async () => {
+      const result = await runCli(['serve'], env);
+      assert.notEqual(result.code, 0);
+      assert.match(result.stderr, /Error: Domain required\. Usage: apitap serve/);
+      assert.ok(!result.stderr.includes('{'), 'human mode must not leak an envelope');
     });
   });
 
@@ -157,6 +167,70 @@ describe('CLI --json failure contract (issue #79)', () => {
         parsed.reason,
         parsed.error,
         'import kept a `reason` field historically; it must mirror `error` until deprecated',
+      );
+    });
+  });
+
+  describe('help prose stays out of `error`', () => {
+    // An agent that surfaces `error` alone should get the defect, not a lecture.
+    // Long guidance goes in `hint`, which also reaches the human stderr line.
+    it('index build separates error, usage and hint', async () => {
+      const result = await runCli(['index', 'bogus-subcommand', '--json'], env);
+      const parsed = assertJsonFailure(result, 'index bogus');
+
+      assert.equal(parsed.error, 'Unknown index subcommand');
+      assert.equal(parsed.usage, 'apitap index build');
+      assert.match(parsed.hint as string, /Force rebuild the search index/);
+      assert.ok(
+        !(parsed.error as string).includes('rebuild'),
+        'help prose must not be jammed into `error`',
+      );
+      assert.match(result.stderr, /Force rebuild the search index/, 'humans keep the guidance too');
+    });
+  });
+
+  describe('exit code agrees with the envelope', () => {
+    // A failed `refresh --json` used to print success:false and exit 0, so a
+    // caller keying on the exit code read it as a success. Same failure-contract
+    // family as #79, and the exact shape of quiet regression that let the
+    // original `auth request` bug through.
+    //
+    // A skill with no oauthConfig, no refreshable tokens and no auth.refreshUrl
+    // takes refreshTokens' browser-free path and returns success:false without
+    // launching Chrome or touching the network.
+    function unrefreshableSkill(domain: string): SkillFile {
+      return {
+        version: '1.2',
+        domain,
+        capturedAt: '2026-02-04T12:00:00.000Z',
+        baseUrl: `https://${domain}`,
+        endpoints: [{
+          id: 'get-thing',
+          method: 'GET',
+          path: '/thing',
+          queryParams: {},
+          headers: {},
+          responseShape: { type: 'object', fields: ['id'] },
+          examples: { request: { url: `https://${domain}/thing`, headers: {} }, responsePreview: null },
+          replayability: { tier: 'green', verified: true, signals: [] },
+        }],
+        metadata: { captureCount: 1, filteredCount: 0, toolVersion: '0.4.0' },
+        provenance: 'self',
+      };
+    }
+
+    it('refresh --json exits non-zero when it reports success:false', async () => {
+      const domain = 'unrefreshable.invalid';
+      await writeSkillFile(unrefreshableSkill(domain), join(testDir, 'skills'));
+
+      const result = await runCli(['refresh', domain, '--json', '--trust-unsigned'], env);
+
+      const parsed = JSON.parse(result.stdout);
+      assert.equal(parsed.success, false, 'expected the browser-free refresh path to report failure');
+      assert.notEqual(
+        result.code,
+        0,
+        'refresh printed success:false but exited 0 — exit code must agree with the envelope',
       );
     });
   });

--- a/test/docs/hermes-skill.test.ts
+++ b/test/docs/hermes-skill.test.ts
@@ -518,13 +518,29 @@ describe('hermes skill states behaviour the code actually has', () => {
     );
   });
 
-  it('keeps index build outside the --json contract', () => {
+  it('keeps index build outside the --json SUCCESS contract', () => {
+    // Issue #79 brought every command's failure path into the --json contract,
+    // `index build` included. What stays true is that its success path prints
+    // human text only — so assert on the success path, not on the whole
+    // function reading a json flag.
     const cliSource = readFileSync(cliPath, 'utf8');
     const fnMatch = cliSource.match(/async function handleIndex\([\s\S]*?\n\}/);
     assert.ok(fnMatch, 'src/cli.ts no longer has handleIndex');
+
+    // Everything after the argument guard is the success path.
+    const successPath = fnMatch[0].slice(fnMatch[0].indexOf('const skillsDir'));
+    assert.ok(successPath, 'handleIndex no longer has a skillsDir success path');
     assert.ok(
-      !/flags(\.json\b|\[['"]json['"]\])/.test(fnMatch[0]),
-      'handleIndex now reads a json flag — SKILL.md documents `apitap index build` as the one command with no --json mode',
+      !/JSON\.stringify/.test(successPath),
+      'handleIndex now emits JSON on success — SKILL.md documents `apitap index build` as having no --json success mode',
+    );
+  });
+
+  it('documents the --json failure envelope', () => {
+    assert.match(
+      readSkill(),
+      /"success": false, "error"/,
+      'SKILL.md must document the --json failure envelope (issue #79)',
     );
   });
 });


### PR DESCRIPTION
Closes #79.

## The problem

`--json` on every command is a stated design decision ("CLI is the API", README + CLAUDE.md), but only the **success** half of that contract was honoured. Usage and validation errors printed human text to stderr and left stdout — the documented machine-output channel — completely empty:

```console
$ apitap show --json
# stdout: (nothing)
# stderr: Error: Domain required. Usage: apitap show <domain>
$ echo $?
1
```

An agent had only the exit code to work with. The MCP server already did the right thing (Zod validation returns a structured tool error), so CLI-driven agents got strictly worse diagnostics than MCP-driven ones for identical mistakes.

## The fix

A single `failCli()` helper that every error exit routes through, so the shape cannot drift per command:

```console
$ apitap show --json
{
  "success": false,
  "error": "Domain required",
  "usage": "apitap show <domain>"
}
```

Answering the open questions from the issue:

1. **Envelope** — `{success: false, error}`, matching `auth request`. Scanned for collisions with success envelopes: none. The `import` paths shipped `{success: false, reason}`, so the helper mirrors `error` into `reason` **at exactly those sites** — nothing parsing today breaks, and `reason` can be deprecated separately.
2. **stderr too** — yes. The human line goes to stderr in both modes. Verified byte-identical for `apitap show`, and a test pins it.
3. **Usage strings** — separate `usage` field. A test asserts `error` never contains `Usage:`.
4. **Back-compat** — the only behaviour anyone could have keyed on is "empty stdout means it failed", which now yields a `success: false` envelope. One existing JSON string changed: the YAML-parse failure emitted `Invalid JSON/YAML: …` to JSON but `Could not parse as JSON or YAML: …` to stderr; the two channels now agree on the human wording.

## Deliberate exceptions

- **`apitap serve`** emits the envelope on **stderr**. Its stdout is the MCP stdio transport, and its `--json` tool list already goes to stderr for that reason. A test asserts serve's stdout stays empty.
- **`apitap doctor`** keeps exit **2** for "the run itself broke", reserving 1 for "findings remain". `failCli` grew an `exitCode` option rather than collapsing them.
- **`handleAuthRequest`** keeps its hand-rolled envelope. That serializer is an explicit allow-list guarding against a future `HandoffResult` field leaking cookies to stdout (added in #78); routing it through a generic helper would move that decision away from the one place documenting it. Both paths already satisfy the contract, and now emit the human line to stderr too.

## Adjacent bug fixed

A failed `apitap refresh --json` printed `success: false` but exited **0** — same failure-contract family, and worse than the reported bug, since a caller keying on the exit code saw a success. The token-redaction allow-list is untouched.

## Docs

`test/docs/hermes-skill.test.ts` asserted `index build` is "the one command with no `--json` mode". That claim is now nuanced rather than false: no `--json` *success* mode, but its failure path conforms like everything else. Narrowed the assertion to the success path and updated `SKILL.md`, `README.md`, and `CLAUDE.md` (the last so future error exits use `failCli` rather than a bare `console.error` + `process.exit`).

## Verification

- `npm test` — **1812 pass / 0 fail**
- `npm run typecheck` — clean
- All five repro commands from the issue body reproduced by hand: each now prints the envelope and exits 1

Tests assert the JSON **shape per command**, not just a non-zero exit — which is how the original `auth request` bug regressed quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiL6kNRS8fYCiQ63KXMDYh